### PR TITLE
M0 close-out: retro + SNES handoff bullets

### DIFF
--- a/docs/retros/M0.md
+++ b/docs/retros/M0.md
@@ -1,0 +1,33 @@
+# M0 — Walking skeleton: retro
+
+Date: 2026-05-02
+PRs: [#3](https://github.com/bpechiney/chippy/pull/3) (foundation), [#4](https://github.com/bpechiney/chippy/pull/4) (skeleton)
+
+## What worked
+
+- **Two-artifact build graph (ADR 0001) paid off on the first day.** `zig build test` runs only against `chippy_core` and never resolves a frontend dep, so CI matrix `ubuntu-latest` ∩ `macos-latest` is purely Zig-toolchain shape — no display server, no audio device, no graphics dep. SNES will inherit this directly.
+- **Headless determinism is real.** Every test passed bit-identically on darwin-arm64 (laptop) and the two CI runners. Nothing in `chippy_core` calls `std.time.Timer` or `std.crypto.random` and the CI grep tests enforce that on every PR. The cross-runner equality test from ADR 0004 wasn't actually needed at M0 (no opcodes execute) but the *invariant* it depends on is in place.
+- **Per-PR loop survived first contact.** Lightweight loop on PR #4: implement → `zig build test` green → push → reviewer agent → CI green → merge. Two iterations (initial + fixup) and we're done. The bootstrap CI exception (PR #3 docs-only, no CI) was honest, time-boxed, and is now closed.
+- **ADR-0001 module skeleton was the right shape.** All twelve `chippy_core` files compiled clean on first try after the Zig 0.16 build graph was right. Nothing felt premature, nothing felt missing.
+
+## What didn't
+
+- **Zig 0.16's std rework is bleeding edge — three rebuild cycles to get `main.zig` right.** `std.process.argsAlloc` is gone (now `std.process.Init.minimal.args.toSlice`); `std.io.getStdOut().writer()` is gone (now `std.Io.File.stdout().writer(io, &buf)`); `Reader.readInt` / `Writer.writeInt` is now `Reader.takeInt` / `Writer.writeInt`; `std.array_list.Managed.writer()` is gone (now `std.Io.Writer.Allocating`). None of this is documented in a migration guide yet — I had to grep the stdlib source. M1 will hit more of this.
+- **`cachix/install-nix-action@v27` is broken on `macos-latest`.** Hits `eDSRecordAlreadyExists` because the runner image pre-creates `_nixbld1`. First M0 CI ran 30s and failed cleanly; switching to `DeterminateSystems/nix-installer-action@v17` + `magic-nix-cache-action@v9` fixed it. macOS run is 7m20s vs Ubuntu's 3m47s — the Mac is the slow path now.
+- **Cold-read reviewer agent flagged false-positive removals.** The `feature-dev:code-reviewer` agent fetched `CLAUDE.md` + `CONTEXT.md` + ADRs + the PR diff but **not the linked GitHub issue**. So it flagged `runUntil` and `deinit` for removal as "unsolicited features," when they're explicitly listed in issue #1's acceptance criteria. The other two findings (raw-bytes serialize, undocumented `read16` wrap) were genuine and worth fixing.
+
+## Surprises
+
+- The reviewer agent's two genuine findings (serialize layout fragility and the `read16` wrap) were both *SNES-relevant*, not just CHIP-8 hygiene. That validates the "SNES-shape from day one" thesis — even at M0 the reviewer found things that wouldn't have mattered for vanilla CHIP-8 alone.
+- The `Cycles = u64` decision survived the milestone unused (no opcodes execute). That's fine: it's there for SNES, not CHIP-8.
+- GitHub's task-list auto-tick requires `- [ ] #N` syntax, not `- [ ] description → #N`. The meta-issue's checkboxes don't auto-tick; have to flip them by hand. Worth knowing for M1+.
+
+## Carry forward to M1
+
+- **Don't sleep on Zig 0.16 stdlib drift.** Whenever an opcode handler needs IO, allocator, or byte ops, expect the API to have moved. Grep the stdlib first; don't trust memory.
+- **The `assemble(...)` helper for inline-assembled test ROMs lands in M1.** Issue #1 already mentions the pattern; M1 needs the helper to make per-opcode tests readable.
+- **Disassembly cases land alongside opcode handlers.** `disasm.zig` returns `.unknown` everywhere today — fill in cases as opcodes ship so the trace writer (M2) has real content from day one.
+
+## Carry forward to SNES
+
+(Promoted to `docs/snes-handoff.md` — see that file for the canonical bullets.)

--- a/docs/snes-handoff.md
+++ b/docs/snes-handoff.md
@@ -6,12 +6,18 @@ Each bullet should link back to the chippy retro that motivated it (e.g., "see `
 
 ## Do
 
-_(empty — populate as chippy work surfaces lessons worth carrying forward)_
+- **Two-artifact split (core module + thin exe) from day one.** Pays off immediately: CI matrix never resolves a graphics dep, headless determinism is enforceable by construction, SNES test ROMs run on the test runner. (See `docs/retros/M0.md`.)
+- **Field-by-field `serialize`/`deserialize` from the first commit, never `std.mem.asBytes` on a struct.** Padding bytes inside structs are ABI- and compiler-version-dependent; raw struct serialization breaks save-state files when fields move. Same shape SNES will need across cartridge / region / mapper variants. (See `docs/retros/M0.md`, reviewer finding on PR #4.)
+- **Brief out-of-line comments on "wraps quietly" semantics in core paths that handle ROM-derived addresses.** When chippy's `Bus.read16` masks at 12 bits, the wrap-around on the second byte fetch is non-obvious; SNES address spaces are larger and have more legitimate boundary conditions, so the same documentation discipline matters more there. (See `docs/retros/M0.md`, reviewer finding on PR #4.)
 
 ## Avoid
 
-_(empty)_
+- **`cachix/install-nix-action` on macOS runners.** Pre-provisioned `_nixbld1` collides with `eDSRecordAlreadyExists`. Use `DeterminateSystems/nix-installer-action@v17` + `magic-nix-cache-action@v9` instead. (See `docs/retros/M0.md`.)
+- **Cold-read reviewer agents without the linked issue body.** The `feature-dev:code-reviewer` agent run on PR #4 read `CLAUDE.md`, `CONTEXT.md`, the ADRs, and the diff — but did **not** fetch the GitHub issue listing the acceptance criteria, and so flagged in-spec methods (`runUntil`, `deinit`) for removal. **For SNES, every reviewer-agent prompt must include either the issue body inline or an explicit `gh issue view` instruction.** (See `docs/retros/M0.md`.)
+- **GitHub task-list checkboxes with descriptive prefixes.** `- [ ] **M0 — ...** → #1` does not auto-tick when #1 closes; only the bare `- [ ] #1` form does. SNES roadmap should use the bare form, or accept manual ticks. (See `docs/retros/M0.md`.)
 
 ## Reconsider
 
-_(empty)_
+- **Tier 2 CLI debug REPL was deferred to "on demand" for chippy.** SNES address space and per-frame instruction count are dramatically larger; revisit whether the REPL should land in the SNES walking skeleton rather than waiting for a forcing function.
+- **The `serialize` save-state format is currently field-by-field with no version header.** Fine for chippy (one schema version, lifetime measured in months). For SNES — long-lived saves, multiple cartridge mappers, eventual save-state forwards-compat — add a 4-byte magic + 2-byte version at the front from the first SNES commit.
+- **CI runs `nix develop -c zig fmt --check`. The `fmt` step is currently after build and tests** — fast-failing is generally better. Reorder for SNES so a formatting violation is the first red.


### PR DESCRIPTION
Closes the M0 milestone per the per-milestone loop in CLAUDE.md.

## Summary

- \`docs/retros/M0.md\` — frozen retro for M0. What worked, what didn't, surprises, carry-forward bullets.
- \`docs/snes-handoff.md\` — three Do, three Avoid, three Reconsider bullets, each linking back to the M0 retro.

The most load-bearing carry-forwards for SNES:
1. Keep the two-artifact split (core module + thin exe). It paid off immediately on chippy and the rationale grows on SNES.
2. Field-by-field \`serialize\`/\`deserialize\` from the first commit; never \`std.mem.asBytes\` on a struct. SNES will need this same shape across mappers and regions.
3. Every cold-read reviewer-agent prompt **must include the linked GitHub issue body** (or an explicit \`gh issue view\` instruction). On PR #4 the reviewer flagged two in-spec methods for removal because it only had the diff.

## Test plan

- [x] No source code changes; documentation-only.
- [x] \`docs/retros/M0.md\` follows the retro template in CLAUDE.md (What worked / What didn't / Surprises / Carry forward to M1 / Carry forward to SNES).
- [x] \`docs/snes-handoff.md\` bullets each link to the retro that motivated them.
- [x] Meta-issue #2 — M0 checkbox already manually ticked (GitHub doesn't auto-tick \`- [ ] description → #N\` form; logged as a SNES Avoid).
- [ ] CI green on both runners (docs-only, but the format check + invariant greps still run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)