### PR TITLE
M1.1 (#8): assemble helper + tracer-bullet dispatch (00E0 + 0NNN no-op)

### DIFF
--- a/src/core/assemble.zig
+++ b/src/core/assemble.zig
@@ -1,0 +1,25 @@
+//! Comptime helper that turns CHIP-8 opcode literals into the big-endian
+//! byte stream `Machine.loadRom` accepts. Lives in `chippy_core` so opcode
+//! tests (here and elsewhere in the module) reach for it without crossing
+//! the module boundary.
+
+const std = @import("std");
+const Machine = @import("machine.zig").Machine;
+
+pub fn assemble(comptime opcodes: anytype) [opcodes.len * 2]u8 {
+    var bytes: [opcodes.len * 2]u8 = undefined;
+    inline for (opcodes, 0..) |op, i| {
+        std.mem.writeInt(u16, bytes[i * 2 ..][0..2], op, .big);
+    }
+    return bytes;
+}
+
+test "assemble emits big-endian byte pairs that loadRom accepts" {
+    const bytes = assemble(.{ 0x00E0, 0x1234 });
+    try std.testing.expectEqualSlices(u8, &.{ 0x00, 0xE0, 0x12, 0x34 }, &bytes);
+
+    var m = Machine.init(.{});
+    defer m.deinit();
+    try m.loadRom(&bytes);
+    try std.testing.expectEqualSlices(u8, &bytes, m.bus.ram[0x200 .. 0x200 + bytes.len]);
+}

--- a/src/core/disasm.zig
+++ b/src/core/disasm.zig
@@ -1,15 +1,39 @@
 //! Tier 1 debug affordance: opcode disassembly. Pure function so it's safe
 //! to call from any context (trace formatting, debugger UI, test failure
-//! messages). M0 returns `.unknown` for everything; cases get filled in as
-//! opcodes ship.
+//! messages). Cases get filled in as opcodes ship; everything else still
+//! lands on `.unknown`.
+
+const std = @import("std");
 
 pub const DisasmEntry = struct {
     mnemonic: []const u8,
+    nnn: u16 = 0,
 
     pub const unknown = DisasmEntry{ .mnemonic = "???" };
 };
 
 pub fn disasm(opcode: u16) DisasmEntry {
-    _ = opcode;
-    return DisasmEntry.unknown;
+    return switch (opcode & 0xF000) {
+        0x0000 => switch (opcode) {
+            0x00E0 => .{ .mnemonic = "CLS" },
+            else => .{ .mnemonic = "SYS NNN", .nnn = opcode & 0x0FFF },
+        },
+        else => DisasmEntry.unknown,
+    };
+}
+
+test "disasm(0x00E0) returns CLS" {
+    const e = disasm(0x00E0);
+    try std.testing.expectEqualStrings("CLS", e.mnemonic);
+}
+
+test "disasm(0x0123) returns SYS NNN with nnn populated" {
+    const e = disasm(0x0123);
+    try std.testing.expectEqualStrings("SYS NNN", e.mnemonic);
+    try std.testing.expectEqual(@as(u16, 0x123), e.nnn);
+}
+
+test "disasm(0xFFFF) still returns the unknown sentinel" {
+    const e = disasm(0xFFFF);
+    try std.testing.expectEqualStrings("???", e.mnemonic);
 }

--- a/src/core/machine.zig
+++ b/src/core/machine.zig
@@ -10,6 +10,7 @@ const Timing = timing_mod.Timing;
 const Cycles = timing_mod.Cycles;
 const Options = @import("options.zig").Options;
 const rom = @import("rom.zig");
+const assemble = @import("assemble.zig").assemble;
 
 pub const StepResult = enum { ran, waiting_for_vblank, halted };
 
@@ -45,8 +46,16 @@ pub const Machine = struct {
     }
 
     pub fn step(self: *Machine) StepResult {
-        _ = self;
-        return .halted;
+        const opcode = self.bus.read16(self.cpu.pc);
+        self.cpu.pc +%= 2;
+        switch (opcode & 0xF000) {
+            0x0000 => switch (opcode) {
+                0x00E0 => self.framebuffer.clear(),
+                else => {},
+            },
+            else => {},
+        }
+        return .ran;
     }
 
     pub fn runCycles(self: *Machine, n: u32) Cycles {
@@ -151,30 +160,12 @@ test "loadRom copies bytes to 0x200 and rejects oversized input" {
     try std.testing.expectError(error.RomTooLarge, m.loadRom(&oversized));
 }
 
-test "step returns halted in M0 (opcodes land at M1)" {
-    var m = Machine.init(.{});
-    defer m.deinit();
-    try std.testing.expectEqual(StepResult.halted, m.step());
-}
-
-test "runCycles stops at halted and reports zero cycles ran" {
+test "runCycles runs all requested cycles when nothing halts" {
     var m = Machine.init(.{});
     defer m.deinit();
     const ran = m.runCycles(100);
-    try std.testing.expectEqual(@as(Cycles, 0), ran);
-    try std.testing.expectEqual(@as(Cycles, 0), m.timing.cycles);
-}
-
-test "runUntil returns halted immediately when step halts" {
-    var m = Machine.init(.{});
-    defer m.deinit();
-
-    const Predicate = struct {
-        fn neverDone(_: *const Machine) bool {
-            return false;
-        }
-    };
-    try std.testing.expectEqual(StepResult.halted, m.runUntil(Predicate.neverDone));
+    try std.testing.expectEqual(@as(Cycles, 100), ran);
+    try std.testing.expectEqual(@as(Cycles, 100), m.timing.cycles);
 }
 
 test "runUntil returns ran when the predicate is already satisfied" {
@@ -192,6 +183,31 @@ test "runUntil returns ran when the predicate is already satisfied" {
 test "deinit is callable on a fresh machine without crashing" {
     var m = Machine.init(.{});
     m.deinit();
+}
+
+test "00E0 clears the framebuffer and advances PC by 2" {
+    var m = Machine.init(.{});
+    defer m.deinit();
+    try m.loadRom(&assemble(.{0x00E0}));
+    m.framebuffer.set(3, 4, 1);
+    m.framebuffer.set(63, 31, 1);
+
+    try std.testing.expectEqual(StepResult.ran, m.step());
+
+    try std.testing.expectEqual(@as(u16, 0x202), m.cpu.pc);
+    for (m.framebuffer.pixels) |px| try std.testing.expectEqual(@as(u1, 0), px);
+}
+
+test "0NNN (non-00E0) is a silent no-op that only advances PC" {
+    var m = Machine.init(.{});
+    defer m.deinit();
+    try m.loadRom(&assemble(.{0x0123}));
+    m.framebuffer.set(10, 5, 1);
+
+    try std.testing.expectEqual(StepResult.ran, m.step());
+
+    try std.testing.expectEqual(@as(u16, 0x202), m.cpu.pc);
+    try std.testing.expectEqual(@as(u1, 1), m.framebuffer.get(10, 5));
 }
 
 test "serialize and deserialize roundtrip preserves machine state" {

--- a/src/core/root.zig
+++ b/src/core/root.zig
@@ -13,6 +13,7 @@ pub const disasm = @import("disasm.zig").disasm;
 pub const DisasmEntry = @import("disasm.zig").DisasmEntry;
 pub const RomError = @import("rom.zig").RomError;
 pub const ROM_MAX_BYTES = @import("bus.zig").ROM_MAX_BYTES;
+pub const assemble = @import("assemble.zig").assemble;
 
 test {
     _ = @import("machine.zig");
@@ -27,4 +28,5 @@ test {
     _ = @import("disasm.zig");
     _ = @import("trace.zig");
     _ = @import("options.zig");
+    _ = @import("assemble.zig");
 }


### PR DESCRIPTION
## Summary

- `assemble(...)` comptime helper in `chippy_core` turns CHIP-8 opcode literals into the big-endian byte stream `Machine.loadRom` accepts, so per-opcode tests stay readable as the rest of the instruction set lands. Uses `std.mem.writeInt(..., .big)` to share the byte-order vocabulary already established by `Machine.serialize`.
- `Machine.step()` is no longer a `.halted` stub: fetches via `Bus.read16`, advances PC by 2, dispatches on the high nibble. `00E0` clears the framebuffer; the rest of the `0NNN` family is a silent no-op (modern interpreters ignore SYS; `00EE` is M2's territory). Unknown high nibbles also fall through to a silent PC-advance — never panic on ROM input (rule 12).
- `disasm` grows real entries for `CLS` and `SYS NNN` and gains an `nnn` operand field on `DisasmEntry` (other operand fields stay zero-defaulted until later sub-issues populate them, per the agent brief).
- Three M0-era tests that asserted `step()` returns `.halted` are retired — M1 has no halting opcode. `runCycles stops at halted` is replaced by the positive contract `runCycles runs all requested cycles when nothing halts` (which exercises the implicit zero-RAM 0NNN no-op stream). The `.halted` variant stays in `StepResult` reserved for future use per the M1 PRD.

Closes #8. Parent PRD: #7.

## Test plan

- [x] `nix develop -c zig build test` green locally
- [x] `nix develop -c zig fmt --check src/ build.zig` clean
- [x] CI grep gates green: no `std.time.Timer` / `std.crypto.random` / `@import.*frontend` in `src/core/`
- [ ] CI green on `ubuntu-latest` ∩ `macos-latest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)