### PR TITLE
M1.2 (#9): register opcodes 1NNN, 6XNN, 7XNN, ANNN + disasm

### DIFF
--- a/src/core/disasm.zig
+++ b/src/core/disasm.zig
@@ -8,6 +8,8 @@ const std = @import("std");
 pub const DisasmEntry = struct {
     mnemonic: []const u8,
     nnn: u16 = 0,
+    x: u4 = 0,
+    nn: u8 = 0,
 
     pub const unknown = DisasmEntry{ .mnemonic = "???" };
 };
@@ -18,6 +20,18 @@ pub fn disasm(opcode: u16) DisasmEntry {
             0x00E0 => .{ .mnemonic = "CLS" },
             else => .{ .mnemonic = "SYS NNN", .nnn = opcode & 0x0FFF },
         },
+        0x1000 => .{ .mnemonic = "JP NNN", .nnn = opcode & 0x0FFF },
+        0x6000 => .{
+            .mnemonic = "LD VX, NN",
+            .x = @intCast((opcode & 0x0F00) >> 8),
+            .nn = @truncate(opcode & 0x00FF),
+        },
+        0x7000 => .{
+            .mnemonic = "ADD VX, NN",
+            .x = @intCast((opcode & 0x0F00) >> 8),
+            .nn = @truncate(opcode & 0x00FF),
+        },
+        0xA000 => .{ .mnemonic = "LD I, NNN", .nnn = opcode & 0x0FFF },
         else => DisasmEntry.unknown,
     };
 }
@@ -31,6 +45,32 @@ test "disasm(0x0123) returns SYS NNN with nnn populated" {
     const e = disasm(0x0123);
     try std.testing.expectEqualStrings("SYS NNN", e.mnemonic);
     try std.testing.expectEqual(@as(u16, 0x123), e.nnn);
+}
+
+test "disasm(0x1456) returns JP NNN with nnn populated" {
+    const e = disasm(0x1456);
+    try std.testing.expectEqualStrings("JP NNN", e.mnemonic);
+    try std.testing.expectEqual(@as(u16, 0x456), e.nnn);
+}
+
+test "disasm(0x6A42) returns LD VX, NN with x and nn populated" {
+    const e = disasm(0x6A42);
+    try std.testing.expectEqualStrings("LD VX, NN", e.mnemonic);
+    try std.testing.expectEqual(@as(u4, 0xA), e.x);
+    try std.testing.expectEqual(@as(u8, 0x42), e.nn);
+}
+
+test "disasm(0x7505) returns ADD VX, NN with x and nn populated" {
+    const e = disasm(0x7505);
+    try std.testing.expectEqualStrings("ADD VX, NN", e.mnemonic);
+    try std.testing.expectEqual(@as(u4, 0x5), e.x);
+    try std.testing.expectEqual(@as(u8, 0x05), e.nn);
+}
+
+test "disasm(0xA789) returns LD I, NNN with nnn populated" {
+    const e = disasm(0xA789);
+    try std.testing.expectEqualStrings("LD I, NNN", e.mnemonic);
+    try std.testing.expectEqual(@as(u16, 0x789), e.nnn);
 }
 
 test "disasm(0xFFFF) still returns the unknown sentinel" {

--- a/src/core/machine.zig
+++ b/src/core/machine.zig
@@ -53,6 +53,10 @@ pub const Machine = struct {
                 0x00E0 => self.framebuffer.clear(),
                 else => {},
             },
+            0x1000 => self.cpu.pc = opcode & 0x0FFF,
+            0x6000 => self.cpu.v[(opcode & 0x0F00) >> 8] = @truncate(opcode & 0x00FF),
+            0x7000 => self.cpu.v[(opcode & 0x0F00) >> 8] +%= @truncate(opcode & 0x00FF),
+            0xA000 => self.cpu.i = opcode & 0x0FFF,
             else => {},
         }
         return .ran;
@@ -196,6 +200,64 @@ test "00E0 clears the framebuffer and advances PC by 2" {
 
     try std.testing.expectEqual(@as(u16, 0x202), m.cpu.pc);
     for (m.framebuffer.pixels) |px| try std.testing.expectEqual(@as(u1, 0), px);
+}
+
+test "1NNN sets PC to NNN" {
+    var m = Machine.init(.{});
+    defer m.deinit();
+    try m.loadRom(&assemble(.{0x1456}));
+
+    try std.testing.expectEqual(StepResult.ran, m.step());
+    try std.testing.expectEqual(@as(u16, 0x456), m.cpu.pc);
+}
+
+test "6XNN loads NN into VX, advances PC, leaves other registers untouched" {
+    var m = Machine.init(.{});
+    defer m.deinit();
+    m.cpu.v[0x3] = 0x99;
+    m.cpu.i = 0x321;
+    try m.loadRom(&assemble(.{0x6A42}));
+
+    try std.testing.expectEqual(StepResult.ran, m.step());
+    try std.testing.expectEqual(@as(u8, 0x42), m.cpu.v[0xA]);
+    try std.testing.expectEqual(@as(u16, 0x202), m.cpu.pc);
+    try std.testing.expectEqual(@as(u8, 0x99), m.cpu.v[0x3]);
+    try std.testing.expectEqual(@as(u16, 0x321), m.cpu.i);
+}
+
+test "7XNN adds NN to VX without touching VF (no wrap)" {
+    var m = Machine.init(.{});
+    defer m.deinit();
+    m.cpu.v[0x5] = 0x10;
+    m.cpu.v[0xF] = 0xAB;
+    try m.loadRom(&assemble(.{0x7505}));
+
+    try std.testing.expectEqual(StepResult.ran, m.step());
+    try std.testing.expectEqual(@as(u8, 0x15), m.cpu.v[0x5]);
+    try std.testing.expectEqual(@as(u8, 0xAB), m.cpu.v[0xF]);
+    try std.testing.expectEqual(@as(u16, 0x202), m.cpu.pc);
+}
+
+test "7XNN wraps at 8 bits without touching VF" {
+    var m = Machine.init(.{});
+    defer m.deinit();
+    m.cpu.v[0x0] = 0xFF;
+    m.cpu.v[0xF] = 0x55;
+    try m.loadRom(&assemble(.{0x7001}));
+
+    try std.testing.expectEqual(StepResult.ran, m.step());
+    try std.testing.expectEqual(@as(u8, 0x00), m.cpu.v[0x0]);
+    try std.testing.expectEqual(@as(u8, 0x55), m.cpu.v[0xF]);
+}
+
+test "ANNN loads NNN into I and advances PC" {
+    var m = Machine.init(.{});
+    defer m.deinit();
+    try m.loadRom(&assemble(.{0xA789}));
+
+    try std.testing.expectEqual(StepResult.ran, m.step());
+    try std.testing.expectEqual(@as(u16, 0x789), m.cpu.i);
+    try std.testing.expectEqual(@as(u16, 0x202), m.cpu.pc);
 }
 
 test "0NNN (non-00E0) is a silent no-op that only advances PC" {


### PR DESCRIPTION
## Summary

- Implements four register/PC-only CHIP-8 opcodes in `Machine.step()`: `1NNN` (JP), `6XNN` (LD VX, NN), `7XNN` (ADD VX, NN with 8-bit wrap, VF untouched), `ANNN` (LD I, NNN).
- Adds `x: u4` and `nn: u8` fields to `DisasmEntry`; populates disasm cases for all four opcodes.
- Tests and code land in the same commit per CLAUDE.md.

`7XNN` deliberately does not touch `VF` — that carry behavior belongs to `8XY4` (M2). The wrap-at-0xFF case is a separate test as a regression guard.

Closes #9.

## Test plan

- [x] `nix develop -c zig build test` green locally (22 tests, all passing)
- [x] `nix develop -c zig fmt --check src/ build.zig` clean
- [x] `chippy_core` invariants unchanged (no time/random/frontend imports added)
- [ ] CI green on `ubuntu-latest` ∩ `macos-latest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)