### PR TITLE
M1.7 (#14): interactive TUI loop + --print/--cycles flags + main.zig dispatch

### DIFF
--- a/src/frontend/cli.zig
+++ b/src/frontend/cli.zig
@@ -3,10 +3,14 @@ const std = @import("std");
 pub const ParsedArgs = struct {
     rom_path: ?[:0]const u8 = null,
     help: bool = false,
+    print: bool = false,
+    cycles: ?u32 = null,
 };
 
 pub const Error = error{
     TooManyPositionalArgs,
+    InvalidCycleCount,
+    MissingCyclesForPrintMode,
 };
 
 pub fn parse(args: []const [:0]const u8) Error!ParsedArgs {
@@ -14,15 +18,24 @@ pub fn parse(args: []const [:0]const u8) Error!ParsedArgs {
     if (args.len == 0) return result;
 
     var positional_count: usize = 0;
-    for (args[1..]) |arg| {
+    var i: usize = 1;
+    while (i < args.len) : (i += 1) {
+        const arg = args[i];
         if (std.mem.eql(u8, arg, "--help") or std.mem.eql(u8, arg, "-h")) {
             result.help = true;
+        } else if (std.mem.eql(u8, arg, "--print")) {
+            result.print = true;
+        } else if (std.mem.eql(u8, arg, "--cycles")) {
+            if (i + 1 >= args.len) return error.InvalidCycleCount;
+            i += 1;
+            result.cycles = std.fmt.parseInt(u32, args[i], 10) catch return error.InvalidCycleCount;
         } else {
             if (positional_count >= 1) return error.TooManyPositionalArgs;
             result.rom_path = arg;
             positional_count += 1;
         }
     }
+    if (result.print and result.cycles == null) return error.MissingCyclesForPrintMode;
     return result;
 }
 
@@ -62,4 +75,22 @@ test "no args returns an empty parse" {
     const result = try parse(&argv);
     try std.testing.expectEqual(@as(?[:0]const u8, null), result.rom_path);
     try std.testing.expectEqual(false, result.help);
+}
+
+test "--cycles with a non-integer value is rejected" {
+    const argv = [_][:0]const u8{ "chippy", "--cycles", "abc", "rom.ch8" };
+    try std.testing.expectError(error.InvalidCycleCount, parse(&argv));
+}
+
+test "--print without --cycles is rejected" {
+    const argv = [_][:0]const u8{ "chippy", "--print", "rom.ch8" };
+    try std.testing.expectError(error.MissingCyclesForPrintMode, parse(&argv));
+}
+
+test "--print --cycles 50 parses cleanly with print, cycles, and rom_path set" {
+    const argv = [_][:0]const u8{ "chippy", "--print", "--cycles", "50", "rom.ch8" };
+    const result = try parse(&argv);
+    try std.testing.expectEqual(true, result.print);
+    try std.testing.expectEqual(@as(?u32, 50), result.cycles);
+    try std.testing.expectEqualStrings("rom.ch8", result.rom_path.?);
 }

--- a/src/frontend/main.zig
+++ b/src/frontend/main.zig
@@ -2,6 +2,8 @@ const std = @import("std");
 const Io = std.Io;
 const core = @import("chippy_core");
 const cli = @import("cli.zig");
+const render = @import("render.zig");
+const tui = @import("tui.zig");
 
 pub fn main(init: std.process.Init) !void {
     const io = init.io;
@@ -38,8 +40,14 @@ pub fn main(init: std.process.Init) !void {
     defer m.deinit();
     try m.loadRom(rom_bytes);
 
-    try stdout.print("loaded {d} bytes from {s}\n", .{ rom_bytes.len, rom_path });
-    try stdout.flush();
+    if (parsed.print) {
+        _ = m.runCycles(parsed.cycles.?);
+        try render.render(&m.framebuffer, stdout);
+        try stdout.flush();
+        return;
+    }
+
+    try tui.run(io, &m, stdout);
 }
 
 fn readRom(io: Io, allocator: std.mem.Allocator, path: [:0]const u8) ![]u8 {

--- a/src/frontend/tui.zig
+++ b/src/frontend/tui.zig
@@ -1,0 +1,23 @@
+//! Interactive terminal loop. Each tick redraws the framebuffer in place via
+//! cursor-home + the half-block renderer, advances the emulator one frame,
+//! then sleeps to ~60 Hz. SIGINT terminates the program through the default
+//! handler — no signal-handler installation is needed for v1, since the loop
+//! has no resources that require explicit teardown beyond the writer the
+//! caller already owns.
+
+const std = @import("std");
+const Io = std.Io;
+const core = @import("chippy_core");
+const render = @import("render.zig");
+
+const FRAME_NS: i96 = 16_666_667;
+
+pub fn run(io: Io, m: *core.Machine, writer: *Io.Writer) !void {
+    while (true) {
+        try writer.writeAll("\x1b[H");
+        try render.render(&m.framebuffer, writer);
+        try writer.flush();
+        m.runFrame();
+        try io.sleep(.fromNanoseconds(FRAME_NS), .awake);
+    }
+}


### PR DESCRIPTION
## Summary
- `cli.zig`: `ParsedArgs` grows `print: bool`, `cycles: ?u32`. Parser restructured to index-based iteration; recognises `--print` and the two-arg form `--cycles N`. New error variants `InvalidCycleCount` and `MissingCyclesForPrintMode`.
- New `src/frontend/tui.zig`: `pub fn run(io, m, writer)` loops cursor-home → render → flush → `runFrame` → `io.sleep(.fromNanoseconds(16_666_667), .awake)` at ~60 Hz. SIGINT terminates via the default signal action (no handler installation needed).
- `main.zig` dispatches on `parsed.print`: print mode runs `cycles` cycles, renders once, exits 0; default mode calls `tui.run`.
- Three new `cli.parse` tests cover the brief's acceptance criteria. `chippy_core` untouched; CI grep invariants unaffected.

Closes #14.

## Test plan
- [x] CLI parse: `--print --cycles 50 rom.ch8` parses with `print=true, cycles=50, rom_path="rom.ch8"`.
- [x] CLI parse: `--print rom.ch8` (no `--cycles`) returns `error.MissingCyclesForPrintMode`.
- [x] CLI parse: `--cycles abc rom.ch8` returns `error.InvalidCycleCount`.
- [x] AI-runnable end-to-end: `nix develop -c zig build run -- --print --cycles 30 tests/test_roms/ibm_logo.ch8` produces exactly 13392 bytes of ANSI half-block output and exits 0. Output is byte-stable across runs and matches the framebuffer the M1.5 golden test asserts on.
- [x] AI-runnable TUI smoke: `./zig-out/bin/chippy tests/test_roms/ibm_logo.ch8` (backgrounded, killed via SIGTERM after 1s) emits ~50 frames, each prefixed with `\x1b[H` cursor-home and the renderer's exact byte sequence.
- [ ] **Eyeball gate (delegated to developer):** `nix develop -c zig build run -- tests/test_roms/ibm_logo.ch8` from a real terminal renders the IBM logo in place and Ctrl+C exits cleanly. The AI-side smoke check above proves the bytes are correct; only the visual confirmation requires a TTY.
- [x] `nix develop -c zig build test` green locally.
- [x] `nix develop -c zig fmt --check src/ build.zig` clean.
- [x] No `chippy_core` files modified; CI grep invariants (`std.time.Timer`, `std.crypto.random`, frontend imports in `src/core/`) unaffected.
- [ ] CI green on `ubuntu-latest` ∩ `macos-latest`.

## Side note for the reviewer
While instrumenting the TUI smoke check I initially measured ~2300 fps — that turned out to be an artifact of `kill -INT` against a backgrounded chippy, which doesn't terminate because Unix shells set SIG_IGN for SIGINT on backgrounded children (job control). Real terminal Ctrl+C hits the foreground process group with SIG_DFL and terminates as expected. SIGTERM/SIGKILL tests confirm the loop runs at ~50 fps, close to the brief's "~60 Hz" target. No code change resulted from this investigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)