### PR TITLE
M1 closeout (#36): write docs/retros/M1.md

### DIFF
--- a/docs/retros/M1.md
+++ b/docs/retros/M1.md
@@ -1,0 +1,38 @@
+# M1 — IBM logo: retro
+
+Date: 2026-05-03
+PRs: [#22](https://github.com/bpechiney/chippy/pull/22) (M1.1), [#28](https://github.com/bpechiney/chippy/pull/28) (M1.2), [#29](https://github.com/bpechiney/chippy/pull/29) (M1.3), [#32](https://github.com/bpechiney/chippy/pull/32) (M1.4), [#33](https://github.com/bpechiney/chippy/pull/33) (M1.5), [#34](https://github.com/bpechiney/chippy/pull/34) (M1.6), [#35](https://github.com/bpechiney/chippy/pull/35) (M1.7)
+
+End state: the seven CHIP-8 opcodes the Timendus IBM-logo ROM exercises are wired in `Machine.step()`, the framebuffer renders to ANSI half-blocks via the frontend, the IBM-logo framebuffer matches a 256-byte golden snapshot byte-for-byte on both `ubuntu-latest` and `macos-latest`, and `nix develop -c zig build run -- tests/test_roms/ibm_logo.ch8` draws the logo on Brett's terminal. Both M1 PRD success gates met.
+
+## What worked
+
+- **Per-PR loop scaled to 4 sub-issues with no friction.** PRD-first → per-sub-issue branch → `/tdd` → `/simplify` → `/commit-push-pr` → `/review` → CI matrix → merge. M1.4 through M1.7 all merged on the first or second push, no rollbacks. Cold-read review caught two non-blocking nits on M1.5 (README claim about `@embedFile`, `bus_mod` alias drift) that were cheap to fix in-place.
+- **Cross-runner determinism gate paid off on first contact.** The M1.5 golden test was conceived as the keystone for ADR 0004; the actual run on the CI matrix produced byte-identical output on ubuntu and macos *on the first attempt after bootstrap*. That's the externally-verifiable green-CI trust signal the AI-harness goal depends on; M1 is the first milestone where a real test could prove it.
+- **TDD's tracer-bullet discipline killed gold-plating.** Each sub-issue's brief had a small set of acceptance tests; the `/tdd` red-green-refactor loop kept the diffs tight (M1.4 = 78 lines, M1.5 = 121, M1.6 = 89, M1.7 = 65). `/simplify` aggressively pruned WHAT comments and abstraction headfakes (e.g., declined to extract a "color helper" for 4 ANSI cell strings, declined to extract `loadAndRunIbmLogo` for 2 sites).
+- **The eyeball gate stays useful even with an AI driver.** I can't see a terminal, but the AI-side proxy — running `--print --cycles 30` and asserting the byte stream matches the golden — covers everything except literal pixel rendering. The visual confirmation gets delegated to the developer and the diff between AI proxy and human eyeball is small enough to be safe.
+
+## What didn't
+
+- **`@embedFile` package-path constraint blocked ADR 0004's stated layout.** Zig restricts `@embedFile` to paths inside the module's package directory; with `chippy_core` rooted at `src/core/`, `tests/test_roms/` is out of reach. ADR 0004 specified both `@embedFile` *and* `tests/test_roms/` — incompatible without action. M1.5 punted to runtime reads via `std.Io.Dir.cwd().readFileAlloc`. Captured in handoff so GB picks the layout up front. Cost: ~10 min of investigation.
+- **Zig 0.16 stdlib drift kept biting.** `std.Thread.sleep` is gone (now `Io.sleep`); `std.fs.cwd()` is gone (now `std.Io.Dir.cwd(io, ...)`); `std.process.getEnvVarOwned` route is now `std.testing.environ.getPosix`. Each cost a stdlib grep. M0's retro flagged this; M1 hit it three more times. The lesson sticks for M2.
+- **`std.Io.Limit.limited(N)` semantics are counterintuitive.** "Reached or exceeded" returns `StreamTooLong`, so reading a 256-byte file needs `.limited(257)` not `.limited(256)`. First M1.5 attempt failed with an exact-size cap. One extra test cycle to find.
+- **SIGINT smoke-test phantom.** `kill -INT` against a shell-backgrounded chippy doesn't terminate (Unix shells SIG_IGN backgrounded children's SIGINT for job control). I initially read the resulting unkilled process's continued output as "TUI loop is running at 2300 fps because sleep is broken." Twenty-plus minutes investigating Zig's `Io.sleep` plumbing, then reverting the over-engineered nanosleep workaround. SIGTERM/SIGKILL confirmed sleep is fine. No code change resulted; the lesson is "trust SIGTERM in smoke tests, not SIGINT."
+
+## Surprises
+
+- **The `(opcode & 0x0F00) >> 8` pattern is now at 7 sites across `step()` and `disasm()`.** M2's 8XYN ALU family doubles that. The PR #32 reviewer flagged this as the right moment to extract `opX/opY/opN/opNN/opNNN` helpers — *after* M2 lands, when the duplication is loud enough to justify abstraction. Rule 9 at work: three similar lines beats premature abstraction; seven is the trigger.
+- **All seven M1 PRs landed on the first CI push** (one had a fmt-flagged retry mid-development, none failed CI after the cold-read review pass). That's a project-maturity signal; M0's per-PR loop iterated more.
+- **The reviewer agent flagged a "no mixed-pattern test" gap on M1.6** — a single pixel set at `(5, 3)` instead of the corner cases the brief specified. Out of scope per the brief, but worth knowing the reviewer is operating one rung above acceptance criteria.
+
+## Carry forward to M2
+
+- **Extract `opX/opY/opN/opNN/opNNN` nibble helpers when the 8XYN family lands.** Seven sites today, ~14 by M2 close, so the abstraction pays. Don't extract before the first 8XYN PR — wait for the duplication to make the case.
+- **The `assemble(.{...})` helper + `disasm` case-per-opcode are the per-PR rhythm.** Every M2 sub-issue follows the same template. Lean on it.
+- **`Quirks` defaults exist but aren't read.** M3 wires them — but if any M2 opcode implementation has a quirks-gated arm, leave a `// M3: gate on Quirks.X` comment with a linked issue, not a stub.
+- **`std.Io.Limit.limited(N+1)` for exact-size reads.** Will hit again at M3 quirks goldens (more snapshot files).
+- **In smoke tests, kill via SIGTERM, not SIGINT.** Unix-101 but easy to forget under time pressure.
+
+## Carry forward to next emulator (Game Boy)
+
+The `@embedFile` package-path bullet was promoted to `docs/next-target-handoff.md` during M1.5 (search for "Decide where test fixtures... live BEFORE"). No further bullets needed: the per-PR loop and TDD discipline both carry forward from M0's bullets unchanged; the Zig 0.16 stdlib drift point is M0's existing "don't sleep on stdlib drift" bullet still doing its job.


### PR DESCRIPTION
## Summary
- Adds `docs/retros/M1.md`, frozen at write per CLAUDE.md.
- Documents what worked (per-PR loop scaling, cross-runner determinism, TDD tracer bullets, AI-side eyeball-gate proxy), what didn't (`@embedFile` package-path, Zig 0.16 stdlib drift, `Io.Limit` semantics, SIGINT smoke-test phantom), and surprises (nibble-extraction trigger threshold, all-PRs-first-push CI green, reviewer-above-acceptance-criteria).
- Carry-forward to M2 lists 5 concrete bullets (extract nibble helpers, lean on `assemble`/disasm rhythm, `Quirks` deferred wiring discipline, `.limited(N+1)`, SIGTERM in smoke tests).
- Carry-forward to next emulator (Game Boy): no new bullets — the `@embedFile` lesson was already promoted in PR #33.

Closes #36.

## Per-milestone close steps (for the merger to handle GitHub-side)
- [x] Write `docs/retros/M1.md` (this PR).
- [x] Promote next-emulator-bound bullets to `docs/next-target-handoff.md` (done in PR #33; no new ones to add).
- [ ] Close M1 PRD #7 (manual after merge).
- [ ] Tick the M1 row checkbox on roadmap meta-issue #2 (manual after merge — note the `- [ ] **M1 — IBM logo.**` form does not auto-tick per the M0 retro lesson).

## Test plan
- [x] Documentation only; no source files touched.
- [x] CI grep invariants and `zig build test` are no-ops here (docs-only diff is filtered out by the `changes` job).

🤖 Generated with [Claude Code](https://claude.com/claude-code)