### PR TITLE
M2.1 (#39): subroutines — 00EE (RET) + 2NNN (CALL NNN) + 4-bit sp wrap

### DIFF
--- a/src/core/cpu.zig
+++ b/src/core/cpu.zig
@@ -9,6 +9,8 @@ pub const Cpu = struct {
     v: [16]u8 = [_]u8{0} ** 16,
     i: u16 = 0,
     pc: u16 = ROM_LOAD_ADDRESS,
-    sp: u8 = 0,
+    // ROM-driven CALL depth never exceeds 16; on violation we wrap rather
+    // than panic the host (rule 12).
+    sp: u4 = 0,
     stack: [16]u16 = [_]u16{0} ** 16,
 };

--- a/src/core/disasm.zig
+++ b/src/core/disasm.zig
@@ -20,9 +20,11 @@ pub fn disasm(opcode: u16) DisasmEntry {
     return switch (opcode & 0xF000) {
         0x0000 => switch (opcode) {
             0x00E0 => .{ .mnemonic = "CLS" },
+            0x00EE => .{ .mnemonic = "RET" },
             else => .{ .mnemonic = "SYS NNN", .nnn = opcode & 0x0FFF },
         },
         0x1000 => .{ .mnemonic = "JP NNN", .nnn = opcode & 0x0FFF },
+        0x2000 => .{ .mnemonic = "CALL NNN", .nnn = opcode & 0x0FFF },
         0x6000 => .{
             .mnemonic = "LD VX, NN",
             .x = @intCast((opcode & 0x0F00) >> 8),
@@ -87,6 +89,17 @@ test "disasm(0xD123) returns DRW VX, VY, N with x, y, n populated" {
     try std.testing.expectEqual(@as(u4, 0x1), e.x);
     try std.testing.expectEqual(@as(u4, 0x2), e.y);
     try std.testing.expectEqual(@as(u4, 0x3), e.n);
+}
+
+test "disasm(0x00EE) returns RET" {
+    const e = disasm(0x00EE);
+    try std.testing.expectEqualStrings("RET", e.mnemonic);
+}
+
+test "disasm(0x2456) returns CALL NNN with nnn populated" {
+    const e = disasm(0x2456);
+    try std.testing.expectEqualStrings("CALL NNN", e.mnemonic);
+    try std.testing.expectEqual(@as(u16, 0x456), e.nnn);
 }
 
 test "disasm(0xFFFF) still returns the unknown sentinel" {

--- a/src/core/machine.zig
+++ b/src/core/machine.zig
@@ -51,9 +51,18 @@ pub const Machine = struct {
         switch (opcode & 0xF000) {
             0x0000 => switch (opcode) {
                 0x00E0 => self.framebuffer.clear(),
+                0x00EE => {
+                    self.cpu.sp -%= 1;
+                    self.cpu.pc = self.cpu.stack[self.cpu.sp];
+                },
                 else => {},
             },
             0x1000 => self.cpu.pc = opcode & 0x0FFF,
+            0x2000 => {
+                self.cpu.stack[self.cpu.sp] = self.cpu.pc;
+                self.cpu.sp +%= 1;
+                self.cpu.pc = opcode & 0x0FFF;
+            },
             0x6000 => self.cpu.v[(opcode & 0x0F00) >> 8] = @truncate(opcode & 0x00FF),
             0x7000 => self.cpu.v[(opcode & 0x0F00) >> 8] +%= @truncate(opcode & 0x00FF),
             0xA000 => self.cpu.i = opcode & 0x0FFF,
@@ -120,7 +129,7 @@ pub const Machine = struct {
         try writer.writeAll(&self.cpu.v);
         try writer.writeInt(u16, self.cpu.i, .big);
         try writer.writeInt(u16, self.cpu.pc, .big);
-        try writer.writeInt(u8, self.cpu.sp, .big);
+        try writer.writeInt(u8, @as(u8, self.cpu.sp), .big);
         for (self.cpu.stack) |entry| try writer.writeInt(u16, entry, .big);
         for (self.framebuffer.pixels) |px| try writer.writeInt(u8, px, .big);
         try writer.writeInt(u16, self.keypad.state, .big);
@@ -135,7 +144,7 @@ pub const Machine = struct {
         try reader.readSliceAll(&self.cpu.v);
         self.cpu.i = try reader.takeInt(u16, .big);
         self.cpu.pc = try reader.takeInt(u16, .big);
-        self.cpu.sp = try reader.takeByte();
+        self.cpu.sp = @truncate(try reader.takeByte());
         for (&self.cpu.stack) |*entry| entry.* = try reader.takeInt(u16, .big);
         for (&self.framebuffer.pixels) |*px| px.* = @intCast(try reader.takeByte());
         self.keypad.state = try reader.takeInt(u16, .big);
@@ -321,6 +330,73 @@ test "DXYN advances PC by 2" {
     try std.testing.expectEqual(@as(u16, 0x202), m.cpu.pc);
 }
 
+test "2NNN pushes PC + 2 onto the return stack and jumps to NNN" {
+    var m = Machine.init(.{});
+    defer m.deinit();
+    try m.loadRom(&assemble(.{0x2456}));
+    const pre_sp = m.cpu.sp;
+    const pre_pc = m.cpu.pc;
+
+    try std.testing.expectEqual(StepResult.ran, m.step());
+
+    try std.testing.expectEqual(@as(u16, 0x456), m.cpu.pc);
+    try std.testing.expectEqual(pre_sp + 1, m.cpu.sp);
+    try std.testing.expectEqual(pre_pc + 2, m.cpu.stack[pre_sp]);
+}
+
+test "00EE pops the return stack into PC and decrements sp" {
+    var m = Machine.init(.{});
+    defer m.deinit();
+    m.cpu.sp = 1;
+    m.cpu.stack[0] = 0x789;
+    try m.loadRom(&assemble(.{0x00EE}));
+
+    try std.testing.expectEqual(StepResult.ran, m.step());
+
+    try std.testing.expectEqual(@as(u16, 0x789), m.cpu.pc);
+    try std.testing.expectEqual(@as(u4, 0), m.cpu.sp);
+}
+
+test "2NNN followed by 00EE returns to the instruction after CALL with sp restored" {
+    var m = Machine.init(.{});
+    defer m.deinit();
+    try m.loadRom(&assemble(.{ 0x2204, 0x0000, 0x00EE }));
+    const pre_sp = m.cpu.sp;
+    const pre_pc = m.cpu.pc;
+
+    _ = m.step();
+    _ = m.step();
+
+    try std.testing.expectEqual(pre_pc + 2, m.cpu.pc);
+    try std.testing.expectEqual(pre_sp, m.cpu.sp);
+}
+
+test "2NNN beyond 16 deep wraps sp at 4 bits rather than panicking the host" {
+    // Vanilla COSMAC VIP semantics treat stack overflow as undefined; we follow
+    // CLAUDE.md rule 12 and wrap quietly instead of panicking on ROM input.
+    var m = Machine.init(.{});
+    defer m.deinit();
+    try m.loadRom(&assemble(.{ 0x2202, 0x2202 }));
+
+    var i: usize = 0;
+    while (i < 17) : (i += 1) _ = m.step();
+
+    try std.testing.expectEqual(@as(u4, 1), m.cpu.sp);
+    try std.testing.expectEqual(@as(u16, 0x204), m.cpu.stack[0]);
+}
+
+test "00EE from sp=0 wraps sp at 4 bits rather than panicking the host" {
+    var m = Machine.init(.{});
+    defer m.deinit();
+    m.cpu.stack[15] = 0xABC;
+    try m.loadRom(&assemble(.{0x00EE}));
+
+    try std.testing.expectEqual(StepResult.ran, m.step());
+
+    try std.testing.expectEqual(@as(u4, 15), m.cpu.sp);
+    try std.testing.expectEqual(@as(u16, 0xABC), m.cpu.pc);
+}
+
 test "0NNN (non-00E0) is a silent no-op that only advances PC" {
     var m = Machine.init(.{});
     defer m.deinit();
@@ -365,9 +441,8 @@ test "serialize and deserialize roundtrip preserves machine state" {
     defer src.deinit();
     src.cpu.v[0xA] = 0x55;
     src.cpu.i = 0x300;
-    src.cpu.pc = 0x250;
-    src.cpu.sp = 3;
-    src.cpu.stack[0] = 0x222;
+    try src.loadRom(&assemble(.{0x2456}));
+    _ = src.step();
     src.timing.cycles = 1234;
     src.timing.delay_timer = 7;
     src.timing.sound_timer = 9;
@@ -386,9 +461,9 @@ test "serialize and deserialize roundtrip preserves machine state" {
 
     try std.testing.expectEqual(@as(u8, 0x55), dst.cpu.v[0xA]);
     try std.testing.expectEqual(@as(u16, 0x300), dst.cpu.i);
-    try std.testing.expectEqual(@as(u16, 0x250), dst.cpu.pc);
-    try std.testing.expectEqual(@as(u8, 3), dst.cpu.sp);
-    try std.testing.expectEqual(@as(u16, 0x222), dst.cpu.stack[0]);
+    try std.testing.expectEqual(@as(u16, 0x456), dst.cpu.pc);
+    try std.testing.expectEqual(@as(u4, 1), dst.cpu.sp);
+    try std.testing.expectEqual(@as(u16, 0x202), dst.cpu.stack[0]);
     try std.testing.expectEqual(@as(Cycles, 1234), dst.timing.cycles);
     try std.testing.expectEqual(@as(u8, 7), dst.timing.delay_timer);
     try std.testing.expectEqual(@as(u8, 9), dst.timing.sound_timer);


### PR DESCRIPTION
## Summary

- Wires `2NNN` (CALL) and `00EE` (RET) into `Machine.step()`. The pre-dispatch `pc +%= 2` already produces "PC + 2" by the time CALL pushes, so the brief's `stack[old_sp] == pre-CALL PC + 2` contract falls out of existing dispatch shape with no extra arithmetic.
- Narrows `Cpu.sp` from `u8` to `u4`. The type itself is the "wrap quietly at 16 entries" mask — same pattern `Bus.read16` already uses for OOB PCs, satisfying CLAUDE.md rule 12 (never panic on ROM input). Save format keeps `sp` on the wire as `u8` (widened on write, truncated on read) so existing saves stay compatible.
- New disasm cases for `RET` and `CALL NNN`.

## Test plan

- [x] `nix develop -c zig build test` green locally
- [x] Per-opcode `2NNN` test: PC, sp, and pushed value
- [x] Per-opcode `00EE` test: PC and sp
- [x] Balanced `CALL`/`RET` round-trip restores sp
- [x] 17 consecutive `2NNN`s wrap sp at 4 bits (sp = 1, stack[0] holds the most recent push)
- [x] `00EE` from sp = 0 wraps to sp = 15 and pops stack[15]
- [x] Existing serialize/deserialize roundtrip extended to drive sp/stack[0] through a real CALL
- [x] CI `chippy_core` invariant grep (no frontend imports, no wall-clock, no OS randomness) clean
- [ ] CI green on `ubuntu-latest` ∩ `macos-latest`

Closes #39.