### PR TITLE
M2.2 (#40): conditional skips — 3XNN + 4XNN + 5XY0 + 9XY0 + silent fallthrough on non-zero low nibbles

### DIFF
--- a/src/core/disasm.zig
+++ b/src/core/disasm.zig
@@ -25,6 +25,24 @@ pub fn disasm(opcode: u16) DisasmEntry {
         },
         0x1000 => .{ .mnemonic = "JP NNN", .nnn = opcode & 0x0FFF },
         0x2000 => .{ .mnemonic = "CALL NNN", .nnn = opcode & 0x0FFF },
+        0x3000 => .{
+            .mnemonic = "SE VX, NN",
+            .x = @intCast((opcode & 0x0F00) >> 8),
+            .nn = @truncate(opcode & 0x00FF),
+        },
+        0x4000 => .{
+            .mnemonic = "SNE VX, NN",
+            .x = @intCast((opcode & 0x0F00) >> 8),
+            .nn = @truncate(opcode & 0x00FF),
+        },
+        0x5000 => switch (opcode & 0x000F) {
+            0x0 => .{
+                .mnemonic = "SE VX, VY",
+                .x = @intCast((opcode & 0x0F00) >> 8),
+                .y = @intCast((opcode & 0x00F0) >> 4),
+            },
+            else => DisasmEntry.unknown,
+        },
         0x6000 => .{
             .mnemonic = "LD VX, NN",
             .x = @intCast((opcode & 0x0F00) >> 8),
@@ -34,6 +52,14 @@ pub fn disasm(opcode: u16) DisasmEntry {
             .mnemonic = "ADD VX, NN",
             .x = @intCast((opcode & 0x0F00) >> 8),
             .nn = @truncate(opcode & 0x00FF),
+        },
+        0x9000 => switch (opcode & 0x000F) {
+            0x0 => .{
+                .mnemonic = "SNE VX, VY",
+                .x = @intCast((opcode & 0x0F00) >> 8),
+                .y = @intCast((opcode & 0x00F0) >> 4),
+            },
+            else => DisasmEntry.unknown,
         },
         0xA000 => .{ .mnemonic = "LD I, NNN", .nnn = opcode & 0x0FFF },
         0xD000 => .{
@@ -100,6 +126,34 @@ test "disasm(0x2456) returns CALL NNN with nnn populated" {
     const e = disasm(0x2456);
     try std.testing.expectEqualStrings("CALL NNN", e.mnemonic);
     try std.testing.expectEqual(@as(u16, 0x456), e.nnn);
+}
+
+test "disasm(0x3542) returns SE VX, NN with x and nn populated" {
+    const e = disasm(0x3542);
+    try std.testing.expectEqualStrings("SE VX, NN", e.mnemonic);
+    try std.testing.expectEqual(@as(u4, 0x5), e.x);
+    try std.testing.expectEqual(@as(u8, 0x42), e.nn);
+}
+
+test "disasm(0x4542) returns SNE VX, NN with x and nn populated" {
+    const e = disasm(0x4542);
+    try std.testing.expectEqualStrings("SNE VX, NN", e.mnemonic);
+    try std.testing.expectEqual(@as(u4, 0x5), e.x);
+    try std.testing.expectEqual(@as(u8, 0x42), e.nn);
+}
+
+test "disasm(0x53A0) returns SE VX, VY with x and y populated" {
+    const e = disasm(0x53A0);
+    try std.testing.expectEqualStrings("SE VX, VY", e.mnemonic);
+    try std.testing.expectEqual(@as(u4, 0x3), e.x);
+    try std.testing.expectEqual(@as(u4, 0xA), e.y);
+}
+
+test "disasm(0x93A0) returns SNE VX, VY with x and y populated" {
+    const e = disasm(0x93A0);
+    try std.testing.expectEqualStrings("SNE VX, VY", e.mnemonic);
+    try std.testing.expectEqual(@as(u4, 0x3), e.x);
+    try std.testing.expectEqual(@as(u4, 0xA), e.y);
 }
 
 test "disasm(0xFFFF) still returns the unknown sentinel" {

--- a/src/core/machine.zig
+++ b/src/core/machine.zig
@@ -63,8 +63,30 @@ pub const Machine = struct {
                 self.cpu.sp +%= 1;
                 self.cpu.pc = opcode & 0x0FFF;
             },
+            0x3000 => {
+                if (self.cpu.v[(opcode & 0x0F00) >> 8] == @as(u8, @truncate(opcode & 0x00FF))) {
+                    self.cpu.pc +%= 2;
+                }
+            },
+            0x4000 => {
+                if (self.cpu.v[(opcode & 0x0F00) >> 8] != @as(u8, @truncate(opcode & 0x00FF))) {
+                    self.cpu.pc +%= 2;
+                }
+            },
+            0x5000 => switch (opcode & 0x000F) {
+                0x0 => if (self.cpu.v[(opcode & 0x0F00) >> 8] == self.cpu.v[(opcode & 0x00F0) >> 4]) {
+                    self.cpu.pc +%= 2;
+                },
+                else => {},
+            },
             0x6000 => self.cpu.v[(opcode & 0x0F00) >> 8] = @truncate(opcode & 0x00FF),
             0x7000 => self.cpu.v[(opcode & 0x0F00) >> 8] +%= @truncate(opcode & 0x00FF),
+            0x9000 => switch (opcode & 0x000F) {
+                0x0 => if (self.cpu.v[(opcode & 0x0F00) >> 8] != self.cpu.v[(opcode & 0x00F0) >> 4]) {
+                    self.cpu.pc +%= 2;
+                },
+                else => {},
+            },
             0xA000 => self.cpu.i = opcode & 0x0FFF,
             0xD000 => {
                 const x = self.cpu.v[(opcode & 0x0F00) >> 8];
@@ -395,6 +417,122 @@ test "00EE from sp=0 wraps sp at 4 bits rather than panicking the host" {
 
     try std.testing.expectEqual(@as(u4, 15), m.cpu.sp);
     try std.testing.expectEqual(@as(u16, 0xABC), m.cpu.pc);
+}
+
+test "3XNN skips the next instruction when VX == NN (PC += 4)" {
+    var m = Machine.init(.{});
+    defer m.deinit();
+    m.cpu.v[0x5] = 0x42;
+    try m.loadRom(&assemble(.{0x3542}));
+
+    try std.testing.expectEqual(StepResult.ran, m.step());
+
+    try std.testing.expectEqual(@as(u16, 0x204), m.cpu.pc);
+}
+
+test "3XNN does not skip when VX != NN (PC += 2)" {
+    var m = Machine.init(.{});
+    defer m.deinit();
+    m.cpu.v[0x5] = 0x41;
+    try m.loadRom(&assemble(.{0x3542}));
+
+    try std.testing.expectEqual(StepResult.ran, m.step());
+
+    try std.testing.expectEqual(@as(u16, 0x202), m.cpu.pc);
+}
+
+test "4XNN skips the next instruction when VX != NN (PC += 4)" {
+    var m = Machine.init(.{});
+    defer m.deinit();
+    m.cpu.v[0x5] = 0x41;
+    try m.loadRom(&assemble(.{0x4542}));
+
+    try std.testing.expectEqual(StepResult.ran, m.step());
+
+    try std.testing.expectEqual(@as(u16, 0x204), m.cpu.pc);
+}
+
+test "4XNN does not skip when VX == NN (PC += 2)" {
+    var m = Machine.init(.{});
+    defer m.deinit();
+    m.cpu.v[0x5] = 0x42;
+    try m.loadRom(&assemble(.{0x4542}));
+
+    try std.testing.expectEqual(StepResult.ran, m.step());
+
+    try std.testing.expectEqual(@as(u16, 0x202), m.cpu.pc);
+}
+
+test "5XY0 skips the next instruction when VX == VY (PC += 4)" {
+    var m = Machine.init(.{});
+    defer m.deinit();
+    m.cpu.v[0x3] = 0x77;
+    m.cpu.v[0xA] = 0x77;
+    try m.loadRom(&assemble(.{0x53A0}));
+
+    try std.testing.expectEqual(StepResult.ran, m.step());
+
+    try std.testing.expectEqual(@as(u16, 0x204), m.cpu.pc);
+}
+
+test "5XY0 does not skip when VX != VY (PC += 2)" {
+    var m = Machine.init(.{});
+    defer m.deinit();
+    m.cpu.v[0x3] = 0x77;
+    m.cpu.v[0xA] = 0x76;
+    try m.loadRom(&assemble(.{0x53A0}));
+
+    try std.testing.expectEqual(StepResult.ran, m.step());
+
+    try std.testing.expectEqual(@as(u16, 0x202), m.cpu.pc);
+}
+
+test "5XY1 (non-zero low nibble) is a silent no-op that only advances PC" {
+    var m = Machine.init(.{});
+    defer m.deinit();
+    m.cpu.v[0x3] = 0x77;
+    m.cpu.v[0xA] = 0x77;
+    try m.loadRom(&assemble(.{0x53A1}));
+
+    try std.testing.expectEqual(StepResult.ran, m.step());
+
+    try std.testing.expectEqual(@as(u16, 0x202), m.cpu.pc);
+}
+
+test "9XY0 skips the next instruction when VX != VY (PC += 4)" {
+    var m = Machine.init(.{});
+    defer m.deinit();
+    m.cpu.v[0x3] = 0x11;
+    m.cpu.v[0xA] = 0x22;
+    try m.loadRom(&assemble(.{0x93A0}));
+
+    try std.testing.expectEqual(StepResult.ran, m.step());
+
+    try std.testing.expectEqual(@as(u16, 0x204), m.cpu.pc);
+}
+
+test "9XY0 does not skip when VX == VY (PC += 2)" {
+    var m = Machine.init(.{});
+    defer m.deinit();
+    m.cpu.v[0x3] = 0x11;
+    m.cpu.v[0xA] = 0x11;
+    try m.loadRom(&assemble(.{0x93A0}));
+
+    try std.testing.expectEqual(StepResult.ran, m.step());
+
+    try std.testing.expectEqual(@as(u16, 0x202), m.cpu.pc);
+}
+
+test "9XY1 (non-zero low nibble) is a silent no-op that only advances PC" {
+    var m = Machine.init(.{});
+    defer m.deinit();
+    m.cpu.v[0x3] = 0x11;
+    m.cpu.v[0xA] = 0x22;
+    try m.loadRom(&assemble(.{0x93A1}));
+
+    try std.testing.expectEqual(StepResult.ran, m.step());
+
+    try std.testing.expectEqual(@as(u16, 0x202), m.cpu.pc);
 }
 
 test "0NNN (non-00E0) is a silent no-op that only advances PC" {


### PR DESCRIPTION
Closes #40.

## Summary

- Implements four conditional skip opcodes in `Machine.step()`:
  - `3XNN` — skip next instruction if `VX == NN`
  - `4XNN` — skip next instruction if `VX != NN`
  - `5XY0` — skip next instruction if `VX == VY`
  - `9XY0` — skip next instruction if `VX != VY`
- `5XY1+` and `9XY1+` (any non-zero low nibble) fall through silently per vanilla VIP semantics.
- Adds disasm cases: `SE VX, NN`, `SNE VX, NN`, `SE VX, VY`, `SNE VX, VY`.

## Tests

- 10 new step() tests: skip-taken (PC += 4) + skip-not-taken (PC += 2) for each of the four opcodes, plus explicit silent-no-op tests for `5XY1` and `9XY1`.
- 4 new disasm tests covering the new mnemonics with `x`, `y`, `nn` populated as appropriate.
- All assertions on real `Machine` / `Bus` / `Cpu` (no mocks per CLAUDE.md rule 11).

## Test plan

- [ ] `nix develop -c zig build test` green locally.
- [ ] CI green on `ubuntu-latest` ∩ `macos-latest`.
- [ ] CI grep tests for `chippy_core` invariants remain green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)