### PR TITLE
M2.3 (#41): bitwise ALU + register copy — 8XY0, 8XY1, 8XY2, 8XY3

### DIFF
--- a/src/core/disasm.zig
+++ b/src/core/disasm.zig
@@ -53,6 +53,29 @@ pub fn disasm(opcode: u16) DisasmEntry {
             .x = @intCast((opcode & 0x0F00) >> 8),
             .nn = @truncate(opcode & 0x00FF),
         },
+        0x8000 => switch (opcode & 0x000F) {
+            0x0 => .{
+                .mnemonic = "LD VX, VY",
+                .x = @intCast((opcode & 0x0F00) >> 8),
+                .y = @intCast((opcode & 0x00F0) >> 4),
+            },
+            0x1 => .{
+                .mnemonic = "OR VX, VY",
+                .x = @intCast((opcode & 0x0F00) >> 8),
+                .y = @intCast((opcode & 0x00F0) >> 4),
+            },
+            0x2 => .{
+                .mnemonic = "AND VX, VY",
+                .x = @intCast((opcode & 0x0F00) >> 8),
+                .y = @intCast((opcode & 0x00F0) >> 4),
+            },
+            0x3 => .{
+                .mnemonic = "XOR VX, VY",
+                .x = @intCast((opcode & 0x0F00) >> 8),
+                .y = @intCast((opcode & 0x00F0) >> 4),
+            },
+            else => DisasmEntry.unknown,
+        },
         0x9000 => switch (opcode & 0x000F) {
             0x0 => .{
                 .mnemonic = "SNE VX, VY",
@@ -147,6 +170,39 @@ test "disasm(0x53A0) returns SE VX, VY with x and y populated" {
     try std.testing.expectEqualStrings("SE VX, VY", e.mnemonic);
     try std.testing.expectEqual(@as(u4, 0x3), e.x);
     try std.testing.expectEqual(@as(u4, 0xA), e.y);
+}
+
+test "disasm(0x83A0) returns LD VX, VY with x and y populated" {
+    const e = disasm(0x83A0);
+    try std.testing.expectEqualStrings("LD VX, VY", e.mnemonic);
+    try std.testing.expectEqual(@as(u4, 0x3), e.x);
+    try std.testing.expectEqual(@as(u4, 0xA), e.y);
+}
+
+test "disasm(0x83A1) returns OR VX, VY with x and y populated" {
+    const e = disasm(0x83A1);
+    try std.testing.expectEqualStrings("OR VX, VY", e.mnemonic);
+    try std.testing.expectEqual(@as(u4, 0x3), e.x);
+    try std.testing.expectEqual(@as(u4, 0xA), e.y);
+}
+
+test "disasm(0x83A2) returns AND VX, VY with x and y populated" {
+    const e = disasm(0x83A2);
+    try std.testing.expectEqualStrings("AND VX, VY", e.mnemonic);
+    try std.testing.expectEqual(@as(u4, 0x3), e.x);
+    try std.testing.expectEqual(@as(u4, 0xA), e.y);
+}
+
+test "disasm(0x83A3) returns XOR VX, VY with x and y populated" {
+    const e = disasm(0x83A3);
+    try std.testing.expectEqualStrings("XOR VX, VY", e.mnemonic);
+    try std.testing.expectEqual(@as(u4, 0x3), e.x);
+    try std.testing.expectEqual(@as(u4, 0xA), e.y);
+}
+
+test "disasm(0x83A8) returns the unknown sentinel for non-canonical 8XYN low nibble" {
+    const e = disasm(0x83A8);
+    try std.testing.expectEqualStrings("???", e.mnemonic);
 }
 
 test "disasm(0x93A0) returns SNE VX, VY with x and y populated" {

--- a/src/core/machine.zig
+++ b/src/core/machine.zig
@@ -81,6 +81,29 @@ pub const Machine = struct {
             },
             0x6000 => self.cpu.v[(opcode & 0x0F00) >> 8] = @truncate(opcode & 0x00FF),
             0x7000 => self.cpu.v[(opcode & 0x0F00) >> 8] +%= @truncate(opcode & 0x00FF),
+            0x8000 => {
+                const x = (opcode & 0x0F00) >> 8;
+                const y = (opcode & 0x00F0) >> 4;
+                switch (opcode & 0x000F) {
+                    0x0 => self.cpu.v[x] = self.cpu.v[y],
+                    0x1 => {
+                        self.cpu.v[x] |= self.cpu.v[y];
+                        // M3: gate on Quirks.vf_reset_on_logical (vanilla = reset; see #38).
+                        if (self.options.quirks.vf_reset_on_logical) self.cpu.v[0xF] = 0;
+                    },
+                    0x2 => {
+                        self.cpu.v[x] &= self.cpu.v[y];
+                        // M3: gate on Quirks.vf_reset_on_logical (vanilla = reset; see #38).
+                        if (self.options.quirks.vf_reset_on_logical) self.cpu.v[0xF] = 0;
+                    },
+                    0x3 => {
+                        self.cpu.v[x] ^= self.cpu.v[y];
+                        // M3: gate on Quirks.vf_reset_on_logical (vanilla = reset; see #38).
+                        if (self.options.quirks.vf_reset_on_logical) self.cpu.v[0xF] = 0;
+                    },
+                    else => {},
+                }
+            },
             0x9000 => switch (opcode & 0x000F) {
                 0x0 => if (self.cpu.v[(opcode & 0x0F00) >> 8] != self.cpu.v[(opcode & 0x00F0) >> 4]) {
                     self.cpu.pc +%= 2;
@@ -533,6 +556,97 @@ test "9XY1 (non-zero low nibble) is a silent no-op that only advances PC" {
     try std.testing.expectEqual(StepResult.ran, m.step());
 
     try std.testing.expectEqual(@as(u16, 0x202), m.cpu.pc);
+}
+
+test "8XY0 copies VY into VX and leaves other registers untouched" {
+    var m = Machine.init(.{});
+    defer m.deinit();
+    m.cpu.v[0x0] = 0x11;
+    m.cpu.v[0x1] = 0x22;
+    m.cpu.v[0x3] = 0x33;
+    m.cpu.v[0xA] = 0x77;
+    m.cpu.v[0xF] = 0xCC;
+    try m.loadRom(&assemble(.{0x83A0}));
+
+    try std.testing.expectEqual(StepResult.ran, m.step());
+
+    try std.testing.expectEqual(@as(u8, 0x77), m.cpu.v[0x3]);
+    try std.testing.expectEqual(@as(u8, 0x77), m.cpu.v[0xA]);
+    try std.testing.expectEqual(@as(u8, 0x11), m.cpu.v[0x0]);
+    try std.testing.expectEqual(@as(u8, 0x22), m.cpu.v[0x1]);
+    try std.testing.expectEqual(@as(u8, 0xCC), m.cpu.v[0xF]);
+    try std.testing.expectEqual(@as(u16, 0x202), m.cpu.pc);
+}
+
+test "8XY1 ORs VY into VX and resets VF to 0 even when VF was non-zero" {
+    var m = Machine.init(.{});
+    defer m.deinit();
+    m.cpu.v[0x3] = 0b1010_0101;
+    m.cpu.v[0xA] = 0b0110_1100;
+    m.cpu.v[0xF] = 0xAB;
+    try m.loadRom(&assemble(.{0x83A1}));
+
+    try std.testing.expectEqual(StepResult.ran, m.step());
+
+    try std.testing.expectEqual(@as(u8, 0b1110_1101), m.cpu.v[0x3]);
+    try std.testing.expectEqual(@as(u8, 0b0110_1100), m.cpu.v[0xA]);
+    try std.testing.expectEqual(@as(u8, 0), m.cpu.v[0xF]);
+    try std.testing.expectEqual(@as(u16, 0x202), m.cpu.pc);
+}
+
+test "8XY2 ANDs VY into VX and resets VF to 0 even when VF was non-zero" {
+    var m = Machine.init(.{});
+    defer m.deinit();
+    m.cpu.v[0x3] = 0b1010_0101;
+    m.cpu.v[0xA] = 0b0110_1100;
+    m.cpu.v[0xF] = 0xAB;
+    try m.loadRom(&assemble(.{0x83A2}));
+
+    try std.testing.expectEqual(StepResult.ran, m.step());
+
+    try std.testing.expectEqual(@as(u8, 0b0010_0100), m.cpu.v[0x3]);
+    try std.testing.expectEqual(@as(u8, 0b0110_1100), m.cpu.v[0xA]);
+    try std.testing.expectEqual(@as(u8, 0), m.cpu.v[0xF]);
+    try std.testing.expectEqual(@as(u16, 0x202), m.cpu.pc);
+}
+
+test "8XY3 XORs VY into VX and resets VF to 0 even when VF was non-zero" {
+    var m = Machine.init(.{});
+    defer m.deinit();
+    m.cpu.v[0x3] = 0b1010_0101;
+    m.cpu.v[0xA] = 0b0110_1100;
+    m.cpu.v[0xF] = 0xAB;
+    try m.loadRom(&assemble(.{0x83A3}));
+
+    try std.testing.expectEqual(StepResult.ran, m.step());
+
+    try std.testing.expectEqual(@as(u8, 0b1100_1001), m.cpu.v[0x3]);
+    try std.testing.expectEqual(@as(u8, 0b0110_1100), m.cpu.v[0xA]);
+    try std.testing.expectEqual(@as(u8, 0), m.cpu.v[0xF]);
+    try std.testing.expectEqual(@as(u16, 0x202), m.cpu.pc);
+}
+
+test "8XYN with non-canonical low nibble is a silent no-op that only advances PC" {
+    // 0x8 / 0x9 / 0xA / 0xB / 0xC / 0xD / 0xF are not vanilla 8XYN ops at M2 —
+    // 8XY4-8XY7 and 8XYE land in M2.5/M2.6, but 8XY8/9/A/B/C/D/F never become
+    // canonical encodings in the vanilla VIP ISA. ROMs containing them must
+    // not panic the host (CLAUDE.md rule 12) and must not perturb V or VF.
+    const non_canonical = [_]u16{ 0x83A8, 0x83A9, 0x83AA, 0x83AB, 0x83AC, 0x83AD, 0x83AF };
+    inline for (non_canonical) |op| {
+        var m = Machine.init(.{});
+        defer m.deinit();
+        m.cpu.v[0x3] = 0xAB;
+        m.cpu.v[0xA] = 0xCD;
+        m.cpu.v[0xF] = 0xEF;
+        try m.loadRom(&assemble(.{op}));
+
+        try std.testing.expectEqual(StepResult.ran, m.step());
+
+        try std.testing.expectEqual(@as(u8, 0xAB), m.cpu.v[0x3]);
+        try std.testing.expectEqual(@as(u8, 0xCD), m.cpu.v[0xA]);
+        try std.testing.expectEqual(@as(u8, 0xEF), m.cpu.v[0xF]);
+        try std.testing.expectEqual(@as(u16, 0x202), m.cpu.pc);
+    }
 }
 
 test "0NNN (non-00E0) is a silent no-op that only advances PC" {


### PR DESCRIPTION
## Summary

- Inner switch on `opcode & 0x000F` for the 0x8000 family: `8XY0` copies VY into VX; `8XY1`/`8XY2`/`8XY3` OR/AND/XOR VY into VX and reset VF to 0 per vanilla COSMAC VIP.
- Reads `Quirks.vf_reset_on_logical` at the call site with a `// M3: gate on Quirks.vf_reset_on_logical` marker (per M2 PRD #38's "read where it would gate" decision) — no stub, M3 just flips the constant.
- Non-canonical low nibbles (`8XY8/9/A/B/C/D/F`) fall through silently — covered by an explicit `inline for` test.
- Disasm grows `LD VX, VY` / `OR VX, VY` / `AND VX, VY` / `XOR VX, VY` cases plus an unknown-sentinel test for the non-canonical fallthrough.

Closes #41. Follow-up nibble-helper extraction lands separately as #43 (M2.4) per CLAUDE.md "refactors are their own PR".

## Test plan

- [x] \`nix develop -c zig build test\` green locally
- [ ] CI green on \`ubuntu-latest\` ∩ \`macos-latest\`
- [x] Per-opcode tests pre-seed \`VF = 0xAB\` and assert it lands at 0 after 8XY1/2/3
- [x] 8XY0 test samples V0/V1/VX/VY/VF to confirm only VX changed
- [x] Non-canonical low nibbles 8XY8/9/A/B/C/D/F covered as silent fall-through
- [x] \`chippy_core\` invariants (no frontend imports, no wall-clock, no OS randomness, no panic-on-ROM) untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)