### PR TITLE
M2.4 (#43): refactor — extract opX/opY/opN/opNN/opNNN nibble helpers (#53)

### DIFF
--- a/src/core/decode.zig
+++ b/src/core/decode.zig
@@ -1,7 +1,6 @@
-//! CHIP-8 opcode nibble field accessors. Pure functions over `u16` opcodes
-//! returning the narrowest type that fits each field, so call sites in
-//! `machine.zig` and `disasm.zig` can drop the `@intCast` / `@truncate` they
-//! otherwise needed for register indexing and immediate values.
+//! Return types are narrowed to the field's natural width so call sites can
+//! index `[16]u8` register banks and assign to `u8` immediates without the
+//! ceremony of a per-site `@intCast` / `@truncate`.
 
 const std = @import("std");
 

--- a/src/core/decode.zig
+++ b/src/core/decode.zig
@@ -1,0 +1,56 @@
+//! CHIP-8 opcode nibble field accessors. Pure functions over `u16` opcodes
+//! returning the narrowest type that fits each field, so call sites in
+//! `machine.zig` and `disasm.zig` can drop the `@intCast` / `@truncate` they
+//! otherwise needed for register indexing and immediate values.
+
+const std = @import("std");
+
+pub fn opX(op: u16) u4 {
+    return @intCast((op & 0x0F00) >> 8);
+}
+
+pub fn opY(op: u16) u4 {
+    return @intCast((op & 0x00F0) >> 4);
+}
+
+pub fn opN(op: u16) u4 {
+    return @intCast(op & 0x000F);
+}
+
+pub fn opNN(op: u16) u8 {
+    return @truncate(op & 0x00FF);
+}
+
+pub fn opNNN(op: u16) u12 {
+    return @intCast(op & 0x0FFF);
+}
+
+test "opX extracts bits 11..8" {
+    try std.testing.expectEqual(@as(u4, 0x0), opX(0x0000));
+    try std.testing.expectEqual(@as(u4, 0xF), opX(0xFFFF));
+    try std.testing.expectEqual(@as(u4, 0x3), opX(0x83A5));
+}
+
+test "opY extracts bits 7..4" {
+    try std.testing.expectEqual(@as(u4, 0x0), opY(0x0000));
+    try std.testing.expectEqual(@as(u4, 0xF), opY(0xFFFF));
+    try std.testing.expectEqual(@as(u4, 0xA), opY(0x83A5));
+}
+
+test "opN extracts bits 3..0" {
+    try std.testing.expectEqual(@as(u4, 0x0), opN(0x0000));
+    try std.testing.expectEqual(@as(u4, 0xF), opN(0xFFFF));
+    try std.testing.expectEqual(@as(u4, 0x5), opN(0x83A5));
+}
+
+test "opNN extracts bits 7..0" {
+    try std.testing.expectEqual(@as(u8, 0x00), opNN(0x0000));
+    try std.testing.expectEqual(@as(u8, 0xFF), opNN(0xFFFF));
+    try std.testing.expectEqual(@as(u8, 0xA5), opNN(0x83A5));
+}
+
+test "opNNN extracts bits 11..0" {
+    try std.testing.expectEqual(@as(u12, 0x000), opNNN(0x0000));
+    try std.testing.expectEqual(@as(u12, 0xFFF), opNNN(0xFFFF));
+    try std.testing.expectEqual(@as(u12, 0x3A5), opNNN(0x83A5));
+}

--- a/src/core/disasm.zig
+++ b/src/core/disasm.zig
@@ -4,6 +4,7 @@
 //! lands on `.unknown`.
 
 const std = @import("std");
+const decode = @import("decode.zig");
 
 pub const DisasmEntry = struct {
     mnemonic: []const u8,
@@ -21,75 +22,75 @@ pub fn disasm(opcode: u16) DisasmEntry {
         0x0000 => switch (opcode) {
             0x00E0 => .{ .mnemonic = "CLS" },
             0x00EE => .{ .mnemonic = "RET" },
-            else => .{ .mnemonic = "SYS NNN", .nnn = opcode & 0x0FFF },
+            else => .{ .mnemonic = "SYS NNN", .nnn = decode.opNNN(opcode) },
         },
-        0x1000 => .{ .mnemonic = "JP NNN", .nnn = opcode & 0x0FFF },
-        0x2000 => .{ .mnemonic = "CALL NNN", .nnn = opcode & 0x0FFF },
+        0x1000 => .{ .mnemonic = "JP NNN", .nnn = decode.opNNN(opcode) },
+        0x2000 => .{ .mnemonic = "CALL NNN", .nnn = decode.opNNN(opcode) },
         0x3000 => .{
             .mnemonic = "SE VX, NN",
-            .x = @intCast((opcode & 0x0F00) >> 8),
-            .nn = @truncate(opcode & 0x00FF),
+            .x = decode.opX(opcode),
+            .nn = decode.opNN(opcode),
         },
         0x4000 => .{
             .mnemonic = "SNE VX, NN",
-            .x = @intCast((opcode & 0x0F00) >> 8),
-            .nn = @truncate(opcode & 0x00FF),
+            .x = decode.opX(opcode),
+            .nn = decode.opNN(opcode),
         },
-        0x5000 => switch (opcode & 0x000F) {
+        0x5000 => switch (decode.opN(opcode)) {
             0x0 => .{
                 .mnemonic = "SE VX, VY",
-                .x = @intCast((opcode & 0x0F00) >> 8),
-                .y = @intCast((opcode & 0x00F0) >> 4),
+                .x = decode.opX(opcode),
+                .y = decode.opY(opcode),
             },
             else => DisasmEntry.unknown,
         },
         0x6000 => .{
             .mnemonic = "LD VX, NN",
-            .x = @intCast((opcode & 0x0F00) >> 8),
-            .nn = @truncate(opcode & 0x00FF),
+            .x = decode.opX(opcode),
+            .nn = decode.opNN(opcode),
         },
         0x7000 => .{
             .mnemonic = "ADD VX, NN",
-            .x = @intCast((opcode & 0x0F00) >> 8),
-            .nn = @truncate(opcode & 0x00FF),
+            .x = decode.opX(opcode),
+            .nn = decode.opNN(opcode),
         },
-        0x8000 => switch (opcode & 0x000F) {
+        0x8000 => switch (decode.opN(opcode)) {
             0x0 => .{
                 .mnemonic = "LD VX, VY",
-                .x = @intCast((opcode & 0x0F00) >> 8),
-                .y = @intCast((opcode & 0x00F0) >> 4),
+                .x = decode.opX(opcode),
+                .y = decode.opY(opcode),
             },
             0x1 => .{
                 .mnemonic = "OR VX, VY",
-                .x = @intCast((opcode & 0x0F00) >> 8),
-                .y = @intCast((opcode & 0x00F0) >> 4),
+                .x = decode.opX(opcode),
+                .y = decode.opY(opcode),
             },
             0x2 => .{
                 .mnemonic = "AND VX, VY",
-                .x = @intCast((opcode & 0x0F00) >> 8),
-                .y = @intCast((opcode & 0x00F0) >> 4),
+                .x = decode.opX(opcode),
+                .y = decode.opY(opcode),
             },
             0x3 => .{
                 .mnemonic = "XOR VX, VY",
-                .x = @intCast((opcode & 0x0F00) >> 8),
-                .y = @intCast((opcode & 0x00F0) >> 4),
+                .x = decode.opX(opcode),
+                .y = decode.opY(opcode),
             },
             else => DisasmEntry.unknown,
         },
-        0x9000 => switch (opcode & 0x000F) {
+        0x9000 => switch (decode.opN(opcode)) {
             0x0 => .{
                 .mnemonic = "SNE VX, VY",
-                .x = @intCast((opcode & 0x0F00) >> 8),
-                .y = @intCast((opcode & 0x00F0) >> 4),
+                .x = decode.opX(opcode),
+                .y = decode.opY(opcode),
             },
             else => DisasmEntry.unknown,
         },
-        0xA000 => .{ .mnemonic = "LD I, NNN", .nnn = opcode & 0x0FFF },
+        0xA000 => .{ .mnemonic = "LD I, NNN", .nnn = decode.opNNN(opcode) },
         0xD000 => .{
             .mnemonic = "DRW VX, VY, N",
-            .x = @intCast((opcode & 0x0F00) >> 8),
-            .y = @intCast((opcode & 0x00F0) >> 4),
-            .n = @intCast(opcode & 0x000F),
+            .x = decode.opX(opcode),
+            .y = decode.opY(opcode),
+            .n = decode.opN(opcode),
         },
         else => DisasmEntry.unknown,
     };

--- a/src/core/machine.zig
+++ b/src/core/machine.zig
@@ -11,6 +11,7 @@ const Cycles = timing_mod.Cycles;
 const Options = @import("options.zig").Options;
 const rom = @import("rom.zig");
 const assemble = @import("assemble.zig").assemble;
+const decode = @import("decode.zig");
 
 pub const StepResult = enum { ran, waiting_for_vblank, halted };
 
@@ -57,34 +58,34 @@ pub const Machine = struct {
                 },
                 else => {},
             },
-            0x1000 => self.cpu.pc = opcode & 0x0FFF,
+            0x1000 => self.cpu.pc = decode.opNNN(opcode),
             0x2000 => {
                 self.cpu.stack[self.cpu.sp] = self.cpu.pc;
                 self.cpu.sp +%= 1;
-                self.cpu.pc = opcode & 0x0FFF;
+                self.cpu.pc = decode.opNNN(opcode);
             },
             0x3000 => {
-                if (self.cpu.v[(opcode & 0x0F00) >> 8] == @as(u8, @truncate(opcode & 0x00FF))) {
+                if (self.cpu.v[decode.opX(opcode)] == decode.opNN(opcode)) {
                     self.cpu.pc +%= 2;
                 }
             },
             0x4000 => {
-                if (self.cpu.v[(opcode & 0x0F00) >> 8] != @as(u8, @truncate(opcode & 0x00FF))) {
+                if (self.cpu.v[decode.opX(opcode)] != decode.opNN(opcode)) {
                     self.cpu.pc +%= 2;
                 }
             },
-            0x5000 => switch (opcode & 0x000F) {
-                0x0 => if (self.cpu.v[(opcode & 0x0F00) >> 8] == self.cpu.v[(opcode & 0x00F0) >> 4]) {
+            0x5000 => switch (decode.opN(opcode)) {
+                0x0 => if (self.cpu.v[decode.opX(opcode)] == self.cpu.v[decode.opY(opcode)]) {
                     self.cpu.pc +%= 2;
                 },
                 else => {},
             },
-            0x6000 => self.cpu.v[(opcode & 0x0F00) >> 8] = @truncate(opcode & 0x00FF),
-            0x7000 => self.cpu.v[(opcode & 0x0F00) >> 8] +%= @truncate(opcode & 0x00FF),
+            0x6000 => self.cpu.v[decode.opX(opcode)] = decode.opNN(opcode),
+            0x7000 => self.cpu.v[decode.opX(opcode)] +%= decode.opNN(opcode),
             0x8000 => {
-                const x = (opcode & 0x0F00) >> 8;
-                const y = (opcode & 0x00F0) >> 4;
-                switch (opcode & 0x000F) {
+                const x = decode.opX(opcode);
+                const y = decode.opY(opcode);
+                switch (decode.opN(opcode)) {
                     0x0 => self.cpu.v[x] = self.cpu.v[y],
                     0x1 => {
                         self.cpu.v[x] |= self.cpu.v[y];
@@ -104,17 +105,17 @@ pub const Machine = struct {
                     else => {},
                 }
             },
-            0x9000 => switch (opcode & 0x000F) {
-                0x0 => if (self.cpu.v[(opcode & 0x0F00) >> 8] != self.cpu.v[(opcode & 0x00F0) >> 4]) {
+            0x9000 => switch (decode.opN(opcode)) {
+                0x0 => if (self.cpu.v[decode.opX(opcode)] != self.cpu.v[decode.opY(opcode)]) {
                     self.cpu.pc +%= 2;
                 },
                 else => {},
             },
-            0xA000 => self.cpu.i = opcode & 0x0FFF,
+            0xA000 => self.cpu.i = decode.opNNN(opcode),
             0xD000 => {
-                const x = self.cpu.v[(opcode & 0x0F00) >> 8];
-                const y = self.cpu.v[(opcode & 0x00F0) >> 4];
-                const n = opcode & 0x000F;
+                const x = self.cpu.v[decode.opX(opcode)];
+                const y = self.cpu.v[decode.opY(opcode)];
+                const n = decode.opN(opcode);
                 var sprite: [15]u8 = undefined;
                 for (0..n) |j| sprite[j] = self.bus.read8(self.cpu.i +% @as(u16, @intCast(j)));
                 const collided = self.framebuffer.xorSprite(x, y, sprite[0..n]);

--- a/src/core/root.zig
+++ b/src/core/root.zig
@@ -14,6 +14,11 @@ pub const DisasmEntry = @import("disasm.zig").DisasmEntry;
 pub const RomError = @import("rom.zig").RomError;
 pub const ROM_MAX_BYTES = @import("bus.zig").ROM_MAX_BYTES;
 pub const assemble = @import("assemble.zig").assemble;
+pub const opX = @import("decode.zig").opX;
+pub const opY = @import("decode.zig").opY;
+pub const opN = @import("decode.zig").opN;
+pub const opNN = @import("decode.zig").opNN;
+pub const opNNN = @import("decode.zig").opNNN;
 
 test {
     _ = @import("machine.zig");
@@ -29,5 +34,6 @@ test {
     _ = @import("trace.zig");
     _ = @import("options.zig");
     _ = @import("assemble.zig");
+    _ = @import("decode.zig");
     _ = @import("golden_ibm_logo.zig");
 }


### PR DESCRIPTION
## Summary

- Extracts the `(opcode & 0x0F00) >> 8` / `(opcode & 0x00F0) >> 4` / `(opcode & 0x000F)` / `(opcode & 0x00FF)` / `(opcode & 0x0FFF)` patterns from `Machine.step()` and `disasm()` into a new pure module `src/core/decode.zig` exposing five helpers — `opX`, `opY`, `opN`, `opNN`, `opNNN` — with narrow return types (`u4`/`u4`/`u4`/`u8`/`u12`).
- Mechanical refactor only: no behavior change, no new opcode handlers, no `Quirks` changes. Existing M0/M1/M2.1–M2.3 tests stay byte-identical green throughout. Re-exported from `root.zig` so M2.11 corax+ golden tests can reach for the helpers without crossing module boundaries.
- Outer family-dispatch `switch (opcode & 0xF000)` stays inline (it's a family discriminator, not a nibble field — would have only two call sites and lands below CLAUDE.md rule 9's three-line threshold). Inner `switch (opcode & 0x000F)` arms inside 5XY0 / 8XYN / 9XY0 become `switch (decode.opN(opcode))` to satisfy the #43 zero-grep acceptance gate.

Closes #43. Implementation plan: #53. Per CLAUDE.md, refactors ship via `/request-refactor-plan` (not `/tdd`) and as their own PR.

## Test plan

- [x] `nix develop -c zig build test` green locally (15 new helper unit tests + all existing tests).
- [x] Grep for the five literal nibble patterns in `src/core/machine.zig` and `src/core/disasm.zig` returns zero matches.
- [x] `chippy_core` invariants intact (no `std.time.Timer`, no `std.crypto.random`, no frontend imports).
- [x] `zig fmt` clean on all four touched files.
- [ ] CI green on `ubuntu-latest` ∩ `macos-latest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)