### PR TITLE
M2.5 (#44): arithmetic ALU — 8XY4, 8XY5, 8XY7 (write VX before VF)

### DIFF
--- a/src/core/disasm.zig
+++ b/src/core/disasm.zig
@@ -75,6 +75,21 @@ pub fn disasm(opcode: u16) DisasmEntry {
                 .x = decode.opX(opcode),
                 .y = decode.opY(opcode),
             },
+            0x4 => .{
+                .mnemonic = "ADD VX, VY",
+                .x = decode.opX(opcode),
+                .y = decode.opY(opcode),
+            },
+            0x5 => .{
+                .mnemonic = "SUB VX, VY",
+                .x = decode.opX(opcode),
+                .y = decode.opY(opcode),
+            },
+            0x7 => .{
+                .mnemonic = "SUBN VX, VY",
+                .x = decode.opX(opcode),
+                .y = decode.opY(opcode),
+            },
             else => DisasmEntry.unknown,
         },
         0x9000 => switch (decode.opN(opcode)) {
@@ -197,6 +212,27 @@ test "disasm(0x83A2) returns AND VX, VY with x and y populated" {
 test "disasm(0x83A3) returns XOR VX, VY with x and y populated" {
     const e = disasm(0x83A3);
     try std.testing.expectEqualStrings("XOR VX, VY", e.mnemonic);
+    try std.testing.expectEqual(@as(u4, 0x3), e.x);
+    try std.testing.expectEqual(@as(u4, 0xA), e.y);
+}
+
+test "disasm(0x83A4) returns ADD VX, VY with x and y populated" {
+    const e = disasm(0x83A4);
+    try std.testing.expectEqualStrings("ADD VX, VY", e.mnemonic);
+    try std.testing.expectEqual(@as(u4, 0x3), e.x);
+    try std.testing.expectEqual(@as(u4, 0xA), e.y);
+}
+
+test "disasm(0x83A5) returns SUB VX, VY with x and y populated" {
+    const e = disasm(0x83A5);
+    try std.testing.expectEqualStrings("SUB VX, VY", e.mnemonic);
+    try std.testing.expectEqual(@as(u4, 0x3), e.x);
+    try std.testing.expectEqual(@as(u4, 0xA), e.y);
+}
+
+test "disasm(0x83A7) returns SUBN VX, VY with x and y populated" {
+    const e = disasm(0x83A7);
+    try std.testing.expectEqualStrings("SUBN VX, VY", e.mnemonic);
     try std.testing.expectEqual(@as(u4, 0x3), e.x);
     try std.testing.expectEqual(@as(u4, 0xA), e.y);
 }

--- a/src/core/machine.zig
+++ b/src/core/machine.zig
@@ -102,6 +102,25 @@ pub const Machine = struct {
                         // M3: gate on Quirks.vf_reset_on_logical (vanilla = reset; see #38).
                         if (self.options.quirks.vf_reset_on_logical) self.cpu.v[0xF] = 0;
                     },
+                    0x4 => {
+                        const vx = self.cpu.v[x];
+                        const vy = self.cpu.v[y];
+                        const sum = @addWithOverflow(vx, vy);
+                        self.cpu.v[x] = sum[0];
+                        self.cpu.v[0xF] = sum[1];
+                    },
+                    0x5 => {
+                        const vx = self.cpu.v[x];
+                        const vy = self.cpu.v[y];
+                        self.cpu.v[x] = vx -% vy;
+                        self.cpu.v[0xF] = @intFromBool(vx >= vy);
+                    },
+                    0x7 => {
+                        const vx = self.cpu.v[x];
+                        const vy = self.cpu.v[y];
+                        self.cpu.v[x] = vy -% vx;
+                        self.cpu.v[0xF] = @intFromBool(vy >= vx);
+                    },
                     else => {},
                 }
             },
@@ -625,6 +644,135 @@ test "8XY3 XORs VY into VX and resets VF to 0 even when VF was non-zero" {
     try std.testing.expectEqual(@as(u8, 0b0110_1100), m.cpu.v[0xA]);
     try std.testing.expectEqual(@as(u8, 0), m.cpu.v[0xF]);
     try std.testing.expectEqual(@as(u16, 0x202), m.cpu.pc);
+}
+
+test "8XY4 ADDs VY into VX and clears VF when no carry occurs" {
+    var m = Machine.init(.{});
+    defer m.deinit();
+    m.cpu.v[0x3] = 0x10;
+    m.cpu.v[0xA] = 0x05;
+    m.cpu.v[0xF] = 0xAB;
+    try m.loadRom(&assemble(.{0x83A4}));
+
+    try std.testing.expectEqual(StepResult.ran, m.step());
+
+    try std.testing.expectEqual(@as(u8, 0x15), m.cpu.v[0x3]);
+    try std.testing.expectEqual(@as(u8, 0x05), m.cpu.v[0xA]);
+    try std.testing.expectEqual(@as(u8, 0), m.cpu.v[0xF]);
+    try std.testing.expectEqual(@as(u16, 0x202), m.cpu.pc);
+}
+
+test "8XY4 wraps at 8 bits and sets VF=1 on carry" {
+    var m = Machine.init(.{});
+    defer m.deinit();
+    m.cpu.v[0x3] = 0xFF;
+    m.cpu.v[0xA] = 0x01;
+    m.cpu.v[0xF] = 0x00;
+    try m.loadRom(&assemble(.{0x83A4}));
+
+    try std.testing.expectEqual(StepResult.ran, m.step());
+
+    try std.testing.expectEqual(@as(u8, 0x00), m.cpu.v[0x3]);
+    try std.testing.expectEqual(@as(u8, 1), m.cpu.v[0xF]);
+    try std.testing.expectEqual(@as(u16, 0x202), m.cpu.pc);
+}
+
+test "8XY4 with X=0xF stores the carry flag in VF, not the arithmetic result" {
+    var m = Machine.init(.{});
+    defer m.deinit();
+    m.cpu.v[0xF] = 0xFF;
+    m.cpu.v[0xA] = 0x01;
+    try m.loadRom(&assemble(.{0x8FA4}));
+
+    try std.testing.expectEqual(StepResult.ran, m.step());
+
+    try std.testing.expectEqual(@as(u8, 1), m.cpu.v[0xF]);
+}
+
+test "8XY5 SUBs VY from VX and sets VF=1 (no-borrow) when VX >= VY" {
+    var m = Machine.init(.{});
+    defer m.deinit();
+    m.cpu.v[0x3] = 0x10;
+    m.cpu.v[0xA] = 0x05;
+    m.cpu.v[0xF] = 0x00;
+    try m.loadRom(&assemble(.{0x83A5}));
+
+    try std.testing.expectEqual(StepResult.ran, m.step());
+
+    try std.testing.expectEqual(@as(u8, 0x0B), m.cpu.v[0x3]);
+    try std.testing.expectEqual(@as(u8, 0x05), m.cpu.v[0xA]);
+    try std.testing.expectEqual(@as(u8, 1), m.cpu.v[0xF]);
+    try std.testing.expectEqual(@as(u16, 0x202), m.cpu.pc);
+}
+
+test "8XY5 wraps at 8 bits and sets VF=0 (borrow) when VX < VY" {
+    var m = Machine.init(.{});
+    defer m.deinit();
+    m.cpu.v[0x3] = 0x00;
+    m.cpu.v[0xA] = 0x01;
+    m.cpu.v[0xF] = 0xAB;
+    try m.loadRom(&assemble(.{0x83A5}));
+
+    try std.testing.expectEqual(StepResult.ran, m.step());
+
+    try std.testing.expectEqual(@as(u8, 0xFF), m.cpu.v[0x3]);
+    try std.testing.expectEqual(@as(u8, 0), m.cpu.v[0xF]);
+    try std.testing.expectEqual(@as(u16, 0x202), m.cpu.pc);
+}
+
+test "8XY5 with X=0xF stores the no-borrow flag in VF, not the arithmetic result" {
+    var m = Machine.init(.{});
+    defer m.deinit();
+    m.cpu.v[0xF] = 0x10;
+    m.cpu.v[0xA] = 0x05;
+    try m.loadRom(&assemble(.{0x8FA5}));
+
+    try std.testing.expectEqual(StepResult.ran, m.step());
+
+    try std.testing.expectEqual(@as(u8, 1), m.cpu.v[0xF]);
+}
+
+test "8XY7 stores VY-VX in VX and sets VF=1 (no-borrow) when VY >= VX" {
+    var m = Machine.init(.{});
+    defer m.deinit();
+    m.cpu.v[0x3] = 0x05;
+    m.cpu.v[0xA] = 0x10;
+    m.cpu.v[0xF] = 0x00;
+    try m.loadRom(&assemble(.{0x83A7}));
+
+    try std.testing.expectEqual(StepResult.ran, m.step());
+
+    try std.testing.expectEqual(@as(u8, 0x0B), m.cpu.v[0x3]);
+    try std.testing.expectEqual(@as(u8, 0x10), m.cpu.v[0xA]);
+    try std.testing.expectEqual(@as(u8, 1), m.cpu.v[0xF]);
+    try std.testing.expectEqual(@as(u16, 0x202), m.cpu.pc);
+}
+
+test "8XY7 wraps at 8 bits and sets VF=0 (borrow) when VY < VX" {
+    var m = Machine.init(.{});
+    defer m.deinit();
+    m.cpu.v[0x3] = 0x01;
+    m.cpu.v[0xA] = 0x00;
+    m.cpu.v[0xF] = 0xAB;
+    try m.loadRom(&assemble(.{0x83A7}));
+
+    try std.testing.expectEqual(StepResult.ran, m.step());
+
+    try std.testing.expectEqual(@as(u8, 0xFF), m.cpu.v[0x3]);
+    try std.testing.expectEqual(@as(u8, 0), m.cpu.v[0xF]);
+    try std.testing.expectEqual(@as(u16, 0x202), m.cpu.pc);
+}
+
+test "8XY7 with X=0xF stores the no-borrow flag in VF, not the arithmetic result" {
+    var m = Machine.init(.{});
+    defer m.deinit();
+    m.cpu.v[0xF] = 0x05;
+    m.cpu.v[0xA] = 0x10;
+    try m.loadRom(&assemble(.{0x8FA7}));
+
+    try std.testing.expectEqual(StepResult.ran, m.step());
+
+    try std.testing.expectEqual(@as(u8, 1), m.cpu.v[0xF]);
 }
 
 test "8XYN with non-canonical low nibble is a silent no-op that only advances PC" {


### PR DESCRIPTION
## Summary

- Implements the three arithmetic ALU opcodes inside the existing `0x8000` switch in `Machine.step()`, using the M2.4 `decode.opX/opY/opN` helpers.
- Result-then-flag write order: VX is written first, then VF receives the carry/no-borrow flag — so when `X == 0xF` the post-step VF holds the flag, not the arithmetic result (corax+ asserts this in M2.11).
- Vanilla COSMAC VIP semantics; quirk gating stays deferred to M3.

## Opcode semantics

| Opcode | Operation | VF |
| --- | --- | --- |
| `8XY4` | `VX +%= VY` (8-bit wrap) via `@addWithOverflow` | carry (1 on overflow) |
| `8XY5` | `VX -%= VY` (8-bit wrap) | **no-borrow** (1 if `VX >= VY`) |
| `8XY7` | `VX = VY -% VX` (8-bit wrap) | **no-borrow** (1 if `VY >= VX`) |

Disasm gains `ADD VX, VY` / `SUB VX, VY` / `SUBN VX, VY`, mirroring the 8XY0–8XY3 shape. The 8XY8/9/A/B/C/D/F silent-no-op fallthrough test is untouched; 8XY6 / 8XYE land in M2.6 (#45).

## Test plan

- [x] `nix develop -c zig build test` — full suite green locally.
- [x] Per-opcode no-carry / no-borrow + carry / borrow-with-wrap tests.
- [x] `X == 0xF` cross-test for each opcode proves the result-first-then-flag write order.
- [x] Disasm tests for each new mnemonic.
- [ ] CI green on `ubuntu-latest` ∩ `macos-latest`.
- [ ] CI grep gates for `chippy_core` invariants remain green.

Closes #44.

🤖 Generated with [Claude Code](https://claude.com/claude-code)