### PR TITLE
M2.7 (#46): indexed jump + random — BNNN (JP V0, NNN) + CXNN (RND VX, NN)

### DIFF
--- a/src/core/disasm.zig
+++ b/src/core/disasm.zig
@@ -111,6 +111,12 @@ pub fn disasm(opcode: u16) DisasmEntry {
             else => DisasmEntry.unknown,
         },
         0xA000 => .{ .mnemonic = "LD I, NNN", .nnn = decode.opNNN(opcode) },
+        0xB000 => .{ .mnemonic = "JP V0, NNN", .nnn = decode.opNNN(opcode) },
+        0xC000 => .{
+            .mnemonic = "RND VX, NN",
+            .x = decode.opX(opcode),
+            .nn = decode.opNN(opcode),
+        },
         0xD000 => .{
             .mnemonic = "DRW VX, VY, N",
             .x = decode.opX(opcode),
@@ -271,6 +277,19 @@ test "disasm(0x93A0) returns SNE VX, VY with x and y populated" {
     try std.testing.expectEqualStrings("SNE VX, VY", e.mnemonic);
     try std.testing.expectEqual(@as(u4, 0x3), e.x);
     try std.testing.expectEqual(@as(u4, 0xA), e.y);
+}
+
+test "disasm(0xB456) returns JP V0, NNN with nnn populated" {
+    const e = disasm(0xB456);
+    try std.testing.expectEqualStrings("JP V0, NNN", e.mnemonic);
+    try std.testing.expectEqual(@as(u16, 0x456), e.nnn);
+}
+
+test "disasm(0xC5AB) returns RND VX, NN with x and nn populated" {
+    const e = disasm(0xC5AB);
+    try std.testing.expectEqualStrings("RND VX, NN", e.mnemonic);
+    try std.testing.expectEqual(@as(u4, 0x5), e.x);
+    try std.testing.expectEqual(@as(u8, 0xAB), e.nn);
 }
 
 test "disasm(0xFFFF) still returns the unknown sentinel" {

--- a/src/core/machine.zig
+++ b/src/core/machine.zig
@@ -143,6 +143,13 @@ pub const Machine = struct {
                 else => {},
             },
             0xA000 => self.cpu.i = decode.opNNN(opcode),
+            0xB000 => {
+                // M3: gate on Quirks.jump_uses_vx (vanilla = V0, not VX; see #56).
+                self.cpu.pc = decode.opNNN(opcode) +% self.cpu.v[0x0];
+            },
+            0xC000 => {
+                self.cpu.v[decode.opX(opcode)] = self.prng.random().int(u8) & decode.opNN(opcode);
+            },
             0xD000 => {
                 const x = self.cpu.v[decode.opX(opcode)];
                 const y = self.cpu.v[decode.opY(opcode)];
@@ -897,6 +904,65 @@ test "8XYN with non-canonical low nibble is a silent no-op that only advances PC
         try std.testing.expectEqual(@as(u8, 0xEF), m.cpu.v[0xF]);
         try std.testing.expectEqual(@as(u16, 0x202), m.cpu.pc);
     }
+}
+
+test "BNNN sets PC to NNN + V0 (vanilla VIP — V0, not VX)" {
+    var m = Machine.init(.{});
+    defer m.deinit();
+    m.cpu.v[0x0] = 0x05;
+    try m.loadRom(&assemble(.{0xB456}));
+
+    try std.testing.expectEqual(StepResult.ran, m.step());
+    try std.testing.expectEqual(@as(u16, 0x45B), m.cpu.pc);
+}
+
+test "BNNN with VX != V0 takes the vanilla path (uses V0, ignores VX)" {
+    // Encoded as 0xBA56 — vanilla reads NNN as the full 12 low bits (0xA56)
+    // and adds V0 (= 0x05) for PC = 0xA5B. The M3 jump_uses_vx quirk would
+    // instead add V[A] (= 0x77) for PC = 0xACD. Setting V0 != V[A] makes the
+    // assertion sensitive to which register was selected.
+    var m = Machine.init(.{});
+    defer m.deinit();
+    m.cpu.v[0x0] = 0x05;
+    m.cpu.v[0xA] = 0x77;
+    try m.loadRom(&assemble(.{0xBA56}));
+
+    try std.testing.expectEqual(StepResult.ran, m.step());
+    try std.testing.expectEqual(@as(u16, 0xA5B), m.cpu.pc);
+}
+
+test "CXNN with NN=0xFF emits the deterministic prng byte stream for the seeded prng" {
+    // Cross-runner determinism gate for CXNN: with `Options.rng_seed` fixed,
+    // the four sourced bytes must match exactly on every host. The expected
+    // values were captured once locally from std.Random.DefaultPrng
+    // (Xoshiro256) seeded with 0xDEADBEEFCAFEBABE — algorithm is platform-
+    // independent, so the expectations are inlined directly.
+    var m = Machine.init(.{ .rng_seed = 0xDEADBEEFCAFEBABE });
+    defer m.deinit();
+    try m.loadRom(&assemble(.{ 0xC1FF, 0xC2FF, 0xC3FF, 0xC4FF }));
+
+    _ = m.step();
+    _ = m.step();
+    _ = m.step();
+    _ = m.step();
+
+    try std.testing.expectEqual(@as(u8, 0xE0), m.cpu.v[0x1]);
+    try std.testing.expectEqual(@as(u8, 0xC3), m.cpu.v[0x2]);
+    try std.testing.expectEqual(@as(u8, 0x44), m.cpu.v[0x3]);
+    try std.testing.expectEqual(@as(u8, 0x18), m.cpu.v[0x4]);
+}
+
+test "CXNN ANDs the random byte with NN (high nibble cleared when NN=0x0F)" {
+    // First seeded byte is 0xE0 (see deterministic-stream test above), so
+    // 0xE0 AND 0x0F = 0x00 — proves both the mask is applied and the high
+    // nibble is cleared.
+    var m = Machine.init(.{ .rng_seed = 0xDEADBEEFCAFEBABE });
+    defer m.deinit();
+    try m.loadRom(&assemble(.{0xC50F}));
+
+    _ = m.step();
+
+    try std.testing.expectEqual(@as(u8, 0x00), m.cpu.v[0x5]);
 }
 
 test "0NNN (non-00E0) is a silent no-op that only advances PC" {

--- a/src/core/machine.zig
+++ b/src/core/machine.zig
@@ -953,16 +953,19 @@ test "CXNN with NN=0xFF emits the deterministic prng byte stream for the seeded 
 }
 
 test "CXNN ANDs the random byte with NN (high nibble cleared when NN=0x0F)" {
-    // First seeded byte is 0xE0 (see deterministic-stream test above), so
-    // 0xE0 AND 0x0F = 0x00 — proves both the mask is applied and the high
-    // nibble is cleared.
+    // First two seeded bytes are 0xE0, 0xC3 (see deterministic-stream test
+    // above). The first 0xC?FF burns 0xE0; the 0xC50F then masks 0xC3 with
+    // 0x0F → 0x03. That non-trivial result distinguishes a real mask from
+    // mutations that always produce zero — the obvious `0xE0 & 0x0F = 0x00`
+    // test would pass even if the mask were dropped to `& 0`.
     var m = Machine.init(.{ .rng_seed = 0xDEADBEEFCAFEBABE });
     defer m.deinit();
-    try m.loadRom(&assemble(.{0xC50F}));
+    try m.loadRom(&assemble(.{ 0xC1FF, 0xC50F }));
 
     _ = m.step();
+    _ = m.step();
 
-    try std.testing.expectEqual(@as(u8, 0x00), m.cpu.v[0x5]);
+    try std.testing.expectEqual(@as(u8, 0x03), m.cpu.v[0x5]);
 }
 
 test "0NNN (non-00E0) is a silent no-op that only advances PC" {


### PR DESCRIPTION
## Summary

- `BNNN` (JP V0, NNN) — vanilla COSMAC VIP: `PC = NNN + V0`. M3 quirks gate-comment links to #56 for the eventual `jump_uses_vx` toggle.
- `CXNN` (RND VX, NN) — `VX = (prng byte) AND NN`, sourced from `Machine.prng` (already seeded from `Options.rng_seed` at M0). No new state added.
- Disasm cases for both: `JP V0, NNN` and `RND VX, NN`.

Closes #46.

## Test plan

- [x] `nix develop -c zig build test` green locally (109 tests pass).
- [x] CI grep invariants: no `std.crypto.random` / `std.time.Timer` / frontend imports introduced in `src/core/`.
- [x] `nix develop -c zig fmt --check src/ build.zig` clean.
- [x] CXNN deterministic-byte-stream test: with `rng_seed = 0xDEADBEEFCAFEBABE`, four `CXNN` (NN=0xFF) instructions produce `0xE0, 0xC3, 0x44, 0x18` — captured-once expectation values inlined for cross-runner determinism (Xoshiro256 is platform-independent).
- [x] CXNN masking test: `NN = 0x0F` against the same seed yields `0x00` (high nibble cleared, mask applied).
- [x] BNNN sanity test: opcode `0xBA56` with `V0 = 0x05`, `V[A] = 0x77` lands at `0xA5B` (V0 path), not `0xACD` (would-be quirk path).
- [ ] CI green on `ubuntu-latest` ∩ `macos-latest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)