### PR TITLE
M2.8 (#47): timer + address-register ops — FX07, FX15, FX1E, FX29

### DIFF
--- a/src/core/bus.zig
+++ b/src/core/bus.zig
@@ -6,6 +6,7 @@
 pub const RAM_SIZE: usize = 4096;
 pub const ROM_LOAD_ADDRESS: u16 = 0x200;
 pub const FONTSET_ADDRESS: u16 = 0x050;
+pub const FONT_GLYPH_BYTES: u16 = 5;
 pub const ROM_MAX_BYTES: usize = RAM_SIZE - ROM_LOAD_ADDRESS;
 
 const FONTSET = [_]u8{

--- a/src/core/disasm.zig
+++ b/src/core/disasm.zig
@@ -123,6 +123,13 @@ pub fn disasm(opcode: u16) DisasmEntry {
             .y = decode.opY(opcode),
             .n = decode.opN(opcode),
         },
+        0xF000 => switch (decode.opNN(opcode)) {
+            0x07 => .{ .mnemonic = "LD VX, DT", .x = decode.opX(opcode) },
+            0x15 => .{ .mnemonic = "LD DT, VX", .x = decode.opX(opcode) },
+            0x1E => .{ .mnemonic = "ADD I, VX", .x = decode.opX(opcode) },
+            0x29 => .{ .mnemonic = "LD F, VX", .x = decode.opX(opcode) },
+            else => DisasmEntry.unknown,
+        },
         else => DisasmEntry.unknown,
     };
 }
@@ -290,6 +297,35 @@ test "disasm(0xC5AB) returns RND VX, NN with x and nn populated" {
     try std.testing.expectEqualStrings("RND VX, NN", e.mnemonic);
     try std.testing.expectEqual(@as(u4, 0x5), e.x);
     try std.testing.expectEqual(@as(u8, 0xAB), e.nn);
+}
+
+test "disasm(0xF307) returns LD VX, DT with x populated" {
+    const e = disasm(0xF307);
+    try std.testing.expectEqualStrings("LD VX, DT", e.mnemonic);
+    try std.testing.expectEqual(@as(u4, 0x3), e.x);
+}
+
+test "disasm(0xF315) returns LD DT, VX with x populated" {
+    const e = disasm(0xF315);
+    try std.testing.expectEqualStrings("LD DT, VX", e.mnemonic);
+    try std.testing.expectEqual(@as(u4, 0x3), e.x);
+}
+
+test "disasm(0xF31E) returns ADD I, VX with x populated" {
+    const e = disasm(0xF31E);
+    try std.testing.expectEqualStrings("ADD I, VX", e.mnemonic);
+    try std.testing.expectEqual(@as(u4, 0x3), e.x);
+}
+
+test "disasm(0xF329) returns LD F, VX with x populated" {
+    const e = disasm(0xF329);
+    try std.testing.expectEqualStrings("LD F, VX", e.mnemonic);
+    try std.testing.expectEqual(@as(u4, 0x3), e.x);
+}
+
+test "disasm(0xF318) returns the unknown sentinel (FX18 lands in M5)" {
+    const e = disasm(0xF318);
+    try std.testing.expectEqualStrings("???", e.mnemonic);
 }
 
 test "disasm(0xFFFF) still returns the unknown sentinel" {

--- a/src/core/machine.zig
+++ b/src/core/machine.zig
@@ -1,6 +1,8 @@
 const std = @import("std");
 const bus_mod = @import("bus.zig");
 const Bus = bus_mod.Bus;
+const FONTSET_ADDRESS = bus_mod.FONTSET_ADDRESS;
+const FONT_GLYPH_BYTES = bus_mod.FONT_GLYPH_BYTES;
 const Cpu = @import("cpu.zig").Cpu;
 const Framebuffer = @import("display.zig").Framebuffer;
 const Keypad = @import("keypad.zig").Keypad;
@@ -158,6 +160,13 @@ pub const Machine = struct {
                 for (0..n) |j| sprite[j] = self.bus.read8(self.cpu.i +% @as(u16, @intCast(j)));
                 const collided = self.framebuffer.xorSprite(x, y, sprite[0..n]);
                 self.cpu.v[0xF] = @intFromBool(collided);
+            },
+            0xF000 => switch (decode.opNN(opcode)) {
+                0x07 => self.cpu.v[decode.opX(opcode)] = self.timing.delay_timer,
+                0x15 => self.timing.delay_timer = self.cpu.v[decode.opX(opcode)],
+                0x1E => self.cpu.i +%= self.cpu.v[decode.opX(opcode)],
+                0x29 => self.cpu.i = FONTSET_ADDRESS + FONT_GLYPH_BYTES * @as(u16, self.cpu.v[decode.opX(opcode)] & 0x0F),
+                else => {},
             },
             else => {},
         }
@@ -980,6 +989,142 @@ test "0NNN (non-00E0) is a silent no-op that only advances PC" {
     try std.testing.expectEqual(@as(u1, 1), m.framebuffer.get(10, 5));
 }
 
+test "FX07 loads the delay timer into VX" {
+    var m = Machine.init(.{});
+    defer m.deinit();
+    m.timing.delay_timer = 42;
+    m.cpu.v[0x3] = 0xAB;
+    try m.loadRom(&assemble(.{0xF307}));
+
+    try std.testing.expectEqual(StepResult.ran, m.step());
+
+    try std.testing.expectEqual(@as(u8, 42), m.cpu.v[0x3]);
+    try std.testing.expectEqual(@as(u8, 42), m.timing.delay_timer);
+    try std.testing.expectEqual(@as(u16, 0x202), m.cpu.pc);
+}
+
+test "FX15 stores VX into the delay timer" {
+    var m = Machine.init(.{});
+    defer m.deinit();
+    m.cpu.v[0x3] = 99;
+    m.timing.delay_timer = 0;
+    try m.loadRom(&assemble(.{0xF315}));
+
+    try std.testing.expectEqual(StepResult.ran, m.step());
+
+    try std.testing.expectEqual(@as(u8, 99), m.timing.delay_timer);
+    try std.testing.expectEqual(@as(u8, 99), m.cpu.v[0x3]);
+    try std.testing.expectEqual(@as(u16, 0x202), m.cpu.pc);
+}
+
+test "FX15 then tickTimers then FX07 observes the 60 Hz decrement through the ROM-visible interface" {
+    var m = Machine.init(.{});
+    defer m.deinit();
+    m.cpu.v[0x3] = 5;
+    try m.loadRom(&assemble(.{ 0xF315, 0xF407 }));
+
+    _ = m.step();
+    m.tickTimers();
+    _ = m.step();
+
+    try std.testing.expectEqual(@as(u8, 4), m.cpu.v[0x4]);
+    try std.testing.expectEqual(@as(u8, 4), m.timing.delay_timer);
+}
+
+test "FX1E adds VX to I without wrap and leaves VF untouched" {
+    var m = Machine.init(.{});
+    defer m.deinit();
+    m.cpu.i = 0x300;
+    m.cpu.v[0x3] = 0x05;
+    m.cpu.v[0xF] = 0xAB;
+    try m.loadRom(&assemble(.{0xF31E}));
+
+    try std.testing.expectEqual(StepResult.ran, m.step());
+
+    try std.testing.expectEqual(@as(u16, 0x305), m.cpu.i);
+    try std.testing.expectEqual(@as(u8, 0xAB), m.cpu.v[0xF]);
+    try std.testing.expectEqual(@as(u16, 0x202), m.cpu.pc);
+}
+
+test "FX1E wraps I at 16 bits and leaves VF untouched (vanilla VIP — no carry write)" {
+    var m = Machine.init(.{});
+    defer m.deinit();
+    m.cpu.i = 0xFFFF;
+    m.cpu.v[0x3] = 0x01;
+    m.cpu.v[0xF] = 0xAB;
+    try m.loadRom(&assemble(.{0xF31E}));
+
+    try std.testing.expectEqual(StepResult.ran, m.step());
+
+    try std.testing.expectEqual(@as(u16, 0x0000), m.cpu.i);
+    try std.testing.expectEqual(@as(u8, 0xAB), m.cpu.v[0xF]);
+}
+
+test "FX29 points I at the 5-byte fontset glyph for each hex digit 0..F" {
+    // Expected glyph bytes mirror the FONTSET table in bus.zig — the test
+    // catches both an incorrect base address and an incorrect stride.
+    const glyphs = [16][5]u8{
+        .{ 0xF0, 0x90, 0x90, 0x90, 0xF0 }, // 0
+        .{ 0x20, 0x60, 0x20, 0x20, 0x70 }, // 1
+        .{ 0xF0, 0x10, 0xF0, 0x80, 0xF0 }, // 2
+        .{ 0xF0, 0x10, 0xF0, 0x10, 0xF0 }, // 3
+        .{ 0x90, 0x90, 0xF0, 0x10, 0x10 }, // 4
+        .{ 0xF0, 0x80, 0xF0, 0x10, 0xF0 }, // 5
+        .{ 0xF0, 0x80, 0xF0, 0x90, 0xF0 }, // 6
+        .{ 0xF0, 0x10, 0x20, 0x40, 0x40 }, // 7
+        .{ 0xF0, 0x90, 0xF0, 0x90, 0xF0 }, // 8
+        .{ 0xF0, 0x90, 0xF0, 0x10, 0xF0 }, // 9
+        .{ 0xF0, 0x90, 0xF0, 0x90, 0x90 }, // A
+        .{ 0xE0, 0x90, 0xE0, 0x90, 0xE0 }, // B
+        .{ 0xF0, 0x80, 0x80, 0x80, 0xF0 }, // C
+        .{ 0xE0, 0x90, 0x90, 0x90, 0xE0 }, // D
+        .{ 0xF0, 0x80, 0xF0, 0x80, 0xF0 }, // E
+        .{ 0xF0, 0x80, 0xF0, 0x80, 0x80 }, // F
+    };
+    for (glyphs, 0..) |expected, digit| {
+        var m = Machine.init(.{});
+        defer m.deinit();
+        m.cpu.v[0x3] = @intCast(digit);
+        try m.loadRom(&assemble(.{0xF329}));
+
+        try std.testing.expectEqual(StepResult.ran, m.step());
+
+        try std.testing.expectEqualSlices(u8, &expected, m.bus.ram[m.cpu.i .. m.cpu.i + FONT_GLYPH_BYTES]);
+    }
+}
+
+test "FX18 falls through silently — advances PC, leaves V/I/timers untouched (sound timer set lands in M5)" {
+    var m = Machine.init(.{});
+    defer m.deinit();
+    m.cpu.v[0x3] = 0x77;
+    m.cpu.i = 0x321;
+    m.timing.sound_timer = 0xAA;
+    m.timing.delay_timer = 0xBB;
+    try m.loadRom(&assemble(.{0xF318}));
+
+    try std.testing.expectEqual(StepResult.ran, m.step());
+
+    try std.testing.expectEqual(@as(u16, 0x202), m.cpu.pc);
+    try std.testing.expectEqual(@as(u8, 0x77), m.cpu.v[0x3]);
+    try std.testing.expectEqual(@as(u16, 0x321), m.cpu.i);
+    try std.testing.expectEqual(@as(u8, 0xAA), m.timing.sound_timer);
+    try std.testing.expectEqual(@as(u8, 0xBB), m.timing.delay_timer);
+}
+
+test "FX29 ignores the high nibble of VX (digit selected from low 4 bits only)" {
+    // VX = 0xA5 → glyph index 0x5; without the mask the index would walk past
+    // the end of the fontset and pick up arbitrary RAM.
+    var m = Machine.init(.{});
+    defer m.deinit();
+    m.cpu.v[0x3] = 0xA5;
+    try m.loadRom(&assemble(.{0xF329}));
+
+    try std.testing.expectEqual(StepResult.ran, m.step());
+
+    const expected = [_]u8{ 0xF0, 0x80, 0xF0, 0x10, 0xF0 };
+    try std.testing.expectEqualSlices(u8, &expected, m.bus.ram[m.cpu.i .. m.cpu.i + FONT_GLYPH_BYTES]);
+}
+
 test "serialize and deserialize roundtrip preserves a live IBM-logo framebuffer" {
     // The hand-set roundtrip test below already covers all 11 fields. This
     // test's value is proving the same discipline survives live DXYN-produced
@@ -1007,15 +1152,20 @@ test "serialize and deserialize roundtrip preserves a live IBM-logo framebuffer"
     try std.testing.expectEqualSlices(u1, &src.framebuffer.pixels, &dst.framebuffer.pixels);
 }
 
-test "serialize and deserialize roundtrip preserves machine state" {
+test "serialize and deserialize roundtrip preserves machine state set by M2.8 timer/I opcodes" {
+    // delay_timer and I are populated via FX15 / FX1E rather than hand-set so
+    // the roundtrip is exercised against state the ROM actually produces.
     var src = Machine.init(.{ .rng_seed = 42 });
     defer src.deinit();
     src.cpu.v[0xA] = 0x55;
+    src.cpu.v[0x3] = 7;
+    src.cpu.v[0x4] = 0x05;
     src.cpu.i = 0x300;
-    try src.loadRom(&assemble(.{0x2456}));
+    try src.loadRom(&assemble(.{ 0xF315, 0xF41E, 0x2456 }));
+    _ = src.step();
+    _ = src.step();
     _ = src.step();
     src.timing.cycles = 1234;
-    src.timing.delay_timer = 7;
     src.timing.sound_timer = 9;
     src.keypad.state = 0x00A0;
     src.keypad.last_released = 0xC;
@@ -1031,10 +1181,10 @@ test "serialize and deserialize roundtrip preserves machine state" {
     try dst.deserialize(&reader);
 
     try std.testing.expectEqual(@as(u8, 0x55), dst.cpu.v[0xA]);
-    try std.testing.expectEqual(@as(u16, 0x300), dst.cpu.i);
+    try std.testing.expectEqual(@as(u16, 0x305), dst.cpu.i);
     try std.testing.expectEqual(@as(u16, 0x456), dst.cpu.pc);
     try std.testing.expectEqual(@as(u4, 1), dst.cpu.sp);
-    try std.testing.expectEqual(@as(u16, 0x202), dst.cpu.stack[0]);
+    try std.testing.expectEqual(@as(u16, 0x206), dst.cpu.stack[0]);
     try std.testing.expectEqual(@as(Cycles, 1234), dst.timing.cycles);
     try std.testing.expectEqual(@as(u8, 7), dst.timing.delay_timer);
     try std.testing.expectEqual(@as(u8, 9), dst.timing.sound_timer);


### PR DESCRIPTION
Closes #47. Parent: #38 (M2 PRD).

## Summary

- Add the FX-family delay-timer, address-register, and fontset opcodes under a new `0xF000` inner switch in `Machine.step()`:
  - `FX07` (LD VX, DT) — `VX = timing.delay_timer`.
  - `FX15` (LD DT, VX) — `timing.delay_timer = VX`.
  - `FX1E` (ADD I, VX) — `I += VX` with 16-bit wrap; no VF write (vanilla VIP).
  - `FX29` (LD F, VX) — `I = FONTSET_ADDRESS + FONT_GLYPH_BYTES * (VX & 0x0F)`.
- `FX18` / `FX0A` continue to fall through silently (M5 / M4 scope).
- Introduce `bus.FONT_GLYPH_BYTES` so the fontset table and FX29 share the glyph stride invariant rather than carrying a magic `5`.
- Disasm: `LD VX, DT`, `LD DT, VX`, `ADD I, VX`, `LD F, VX` (with `x` populated).
- Existing serialize/deserialize roundtrip test now populates `delay_timer` and `I` via FX15 / FX1E rather than hand-set, exercising the roundtrip against state the ROM actually produces.

## Test plan

- [x] `nix develop -c zig build test` green locally.
- [ ] CI green on `ubuntu-latest` ∩ `macos-latest`.
- [ ] CI grep tests for `chippy_core` invariants remain green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)