### PR TITLE
docs: codify lessons-gate as per-PR loop step 6

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,9 +65,9 @@ Wraps the per-PR loop. See ADR 0007.
 1. Pick `ready-for-agent` sub-issue. Branch `N-slug` from latest `origin/master`. Enforced mechanically: a project-level PreToolUse hook (ADR 0011) blocks `Edit`/`Write`/`MultiEdit` while on `master` and while on a branch whose upstream is `[gone]` (already merged). Post-merge cleanup — checkout master, fetch, pull --rebase, delete the merged branch — runs automatically via PostToolUse on `gh pr merge` and via SessionStart on every fresh-context boundary (`startup`, `resume`, `clear`).
 2. Implement via `/tdd` — tracer-bullet red-green-refactor against the public surface declared in the agent brief. Tests and code land in the same commit. Test the real `Bus` / `Cpu` / `Machine` (rule 11). If the first failing test forces a contract decision the PRD did not make, stop and sharpen the PRD before continuing — that is the ambiguity signal, not a cue to keep coding. Enforced mechanically: a project-level PreToolUse hook (ADR 0009) blocks `Edit`/`Write`/`MultiEdit` on `src/**` while on an issue branch until `/tdd` is invoked in the current session.
 3. `/simplify` on the diff.
-4. `/commit`.
-5. `/commit-push-pr`.
-6. `/review` (or the `feature-dev:code-reviewer` agent) for cold-read review. Per rule 13, defer a flagged gap only with an evidence-grounded argument that it isn't real.
+4. `/commit-push-pr` — opens the PR. Use `/commit` + `git push` for any subsequent commits on the branch.
+5. `/code-review:code-review` for cold-read review. Per rule 13, defer a flagged gap only with an evidence-grounded argument that it isn't real.
+6. **Lessons gate.** Explicitly ask: did this PR teach the next emulator anything non-obvious — a trap, a shape, a procedure? If yes, append a bullet to `docs/next-target-handoff.md`, `/commit` + `git push` to the PR branch, re-await CI. The bullet ships in the same PR as the work that motivated it; a docs-only follow-up PR is a workflow violation, not a fallback. If no lesson emerged, no commit — proceed to step 7.
 7. CI green on `ubuntu-latest` ∩ `macos-latest`.
 8. Merge.
 
@@ -84,7 +84,7 @@ Wraps the per-PR loop. See ADR 0007.
 
 ## Lessons capture
 
-- Per-PR close: if a non-obvious lesson emerged, append a bullet to `docs/next-target-handoff.md` *now*. Don't defer.
+- **Per-PR close: lessons ship in the same PR, never a follow-up.** Per-PR-loop step 6 is the explicit gate. If a non-obvious lesson emerged, the bullet on `docs/next-target-handoff.md` lands as a commit on the PR branch *before* merge. A docs-only follow-up PR is a workflow violation — not a fallback for "I forgot."
 - Per-milestone close: write `docs/retros/MN.md` (≤ 1 page). Promote next-emulator-bound bullets to handoff with back-reference.
 - On architecture reversal: new ADR + retro/handoff update.
 - `docs/retros/MN.md` is **frozen after write** — never edit; supersede if needed.


### PR DESCRIPTION
## Summary

- Insert step 6 ("Lessons gate") into the per-PR loop, before CI/merge — explicitly evaluate whether the PR teaches the next emulator anything non-obvious; if yes, the handoff bullet lands as a commit on the PR branch before merge.
- Collapse the redundant `/commit` step into `/commit-push-pr` (which already does add+commit+push+`gh pr create` in one shot). `/commit` remains the right tool for *follow-up* commits on an open PR (e.g., `/code-review:code-review` fix-ups, the lessons-gate handoff bullet itself).
- Switch the cold-read review slot from `/review` / `feature-dev:code-reviewer` to `/code-review:code-review`.
- Sharpen the "Per-PR close" bullet so "now" is unambiguous: same PR, never a follow-up. A docs-only follow-up handoff PR is now an explicit workflow violation.

## Why now

Recent git history shows the prose-only "Don't defer" rule decaying into a recurring docs-only follow-up pattern:

| Triggering PR | Docs-only follow-up |
|---|---|
| #60 (M2.9 bus-private) | #62 |
| #82 (M4.2 5-quirks)    | 90c2a26 |
| #86 (golden_harness)   | #88 |

Plus #66 / #75 for milestone closeouts. The agent kept reading "now" as "shortly after merge."

## Test plan

- [ ] Read the diff against `CLAUDE.md` — only the per-PR loop section and the "Lessons capture" bullet should change.
- [ ] Confirm the new step 6 references are internally consistent (the `Lessons capture` section now says "step 6 is the explicit gate").
- [ ] Confirm no ADR or hook is required — this is a prose-only enforcement layer on an existing rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)