### PR TITLE
chore: enable code-review plugin in project settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -4,8 +4,14 @@
       {
         "matcher": "Edit|Write|MultiEdit",
         "hooks": [
-          { "type": "command", "command": ".claude/hooks/check-tdd-invoked.sh" },
-          { "type": "command", "command": ".claude/hooks/check-branch-discipline.sh" }
+          {
+            "type": "command",
+            "command": ".claude/hooks/check-tdd-invoked.sh"
+          },
+          {
+            "type": "command",
+            "command": ".claude/hooks/check-branch-discipline.sh"
+          }
         ]
       }
     ],
@@ -13,7 +19,10 @@
       {
         "matcher": "Bash",
         "hooks": [
-          { "type": "command", "command": ".claude/hooks/post-merge-cleanup.sh" }
+          {
+            "type": "command",
+            "command": ".claude/hooks/post-merge-cleanup.sh"
+          }
         ]
       }
     ],
@@ -21,21 +30,33 @@
       {
         "matcher": "startup",
         "hooks": [
-          { "type": "command", "command": ".claude/hooks/session-start-sync.sh" }
+          {
+            "type": "command",
+            "command": ".claude/hooks/session-start-sync.sh"
+          }
         ]
       },
       {
         "matcher": "resume",
         "hooks": [
-          { "type": "command", "command": ".claude/hooks/session-start-sync.sh" }
+          {
+            "type": "command",
+            "command": ".claude/hooks/session-start-sync.sh"
+          }
         ]
       },
       {
         "matcher": "clear",
         "hooks": [
-          { "type": "command", "command": ".claude/hooks/session-start-sync.sh" }
+          {
+            "type": "command",
+            "command": ".claude/hooks/session-start-sync.sh"
+          }
         ]
       }
     ]
+  },
+  "enabledPlugins": {
+    "code-review@claude-plugins-official": true
   }
 }


### PR DESCRIPTION
## Summary

- Enables the `code-review@claude-plugins-official` plugin in `.claude/settings.json` so `/code-review:code-review` is wired up out of the box for any contributor cloning the repo.
- This is the follow-up to PR #90, which codified `/code-review:code-review` as the canonical cold-read review skill in the per-PR loop step 5.
- The hook-block JSON reformat (compact one-liners → multi-line indented form) is the plugin installer's default. Committing the reformatted shape now keeps future settings.json diffs minimal — without this, every subsequent edit would carry a noisy reformat alongside the substantive change.

## Test plan

- [ ] Confirm `enabledPlugins` block points at `code-review@claude-plugins-official: true`.
- [ ] Confirm the hook-block content (commands, matchers) is identical to pre-PR — only whitespace/structure changed.
- [ ] Confirm `/code-review:code-review` is invocable in a fresh Claude Code session opening this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)