### PR TITLE
M5.1: FX18 wiring — sound timer set + paired vanilla unit tests + disasm

### DIFF
--- a/src/core/disasm.zig
+++ b/src/core/disasm.zig
@@ -131,6 +131,7 @@ pub fn disasm(opcode: u16) DisasmEntry {
         0xF000 => switch (decode.opNN(opcode)) {
             0x07 => .{ .mnemonic = "LD VX, DT", .x = decode.opX(opcode) },
             0x15 => .{ .mnemonic = "LD DT, VX", .x = decode.opX(opcode) },
+            0x18 => .{ .mnemonic = "LD ST, VX", .x = decode.opX(opcode) },
             0x1E => .{ .mnemonic = "ADD I, VX", .x = decode.opX(opcode) },
             0x29 => .{ .mnemonic = "LD F, VX", .x = decode.opX(opcode) },
             0x33 => .{ .mnemonic = "LD B, VX", .x = decode.opX(opcode) },
@@ -348,9 +349,10 @@ test "disasm(0xF329) returns LD F, VX with x populated" {
     try std.testing.expectEqual(@as(u4, 0x3), e.x);
 }
 
-test "disasm(0xF318) returns the unknown sentinel (FX18 lands in M5)" {
+test "disasm(0xF318) returns LD ST, VX with x populated" {
     const e = disasm(0xF318);
-    try std.testing.expectEqualStrings("???", e.mnemonic);
+    try std.testing.expectEqualStrings("LD ST, VX", e.mnemonic);
+    try std.testing.expectEqual(@as(u4, 0x3), e.x);
 }
 
 test "disasm(0xF333) returns LD B, VX with x populated" {

--- a/src/core/machine.zig
+++ b/src/core/machine.zig
@@ -198,6 +198,7 @@ pub const Machine = struct {
                     }
                 },
                 0x15 => self.timing.delay_timer = self.cpu.v[decode.opX(opcode)],
+                0x18 => self.timing.sound_timer = self.cpu.v[decode.opX(opcode)],
                 0x1E => self.cpu.i +%= self.cpu.v[decode.opX(opcode)],
                 0x29 => self.cpu.i = FONTSET_ADDRESS + FONT_GLYPH_BYTES * @as(u16, self.cpu.v[decode.opX(opcode)] & 0x0F),
                 0x33 => {
@@ -1565,22 +1566,47 @@ test "FX29 points I at the 5-byte fontset glyph for each hex digit 0..F" {
     }
 }
 
-test "FX18 falls through silently — advances PC, leaves V/I/timers untouched (sound timer set lands in M5)" {
+test "FX18 stores VX into the sound timer" {
     var m = Machine.init(.{});
     defer m.deinit();
-    m.cpu.v[0x3] = 0x77;
-    m.cpu.i = 0x321;
-    m.timing.sound_timer = 0xAA;
+    m.cpu.v[0x3] = 99;
+    m.timing.sound_timer = 0;
     m.timing.delay_timer = 0xBB;
     try m.loadRom(&assemble(.{0xF318}));
 
     try std.testing.expectEqual(StepResult.ran, m.step());
 
-    try std.testing.expectEqual(@as(u16, 0x202), m.cpu.pc);
-    try std.testing.expectEqual(@as(u8, 0x77), m.cpu.v[0x3]);
-    try std.testing.expectEqual(@as(u16, 0x321), m.cpu.i);
-    try std.testing.expectEqual(@as(u8, 0xAA), m.timing.sound_timer);
+    try std.testing.expectEqual(@as(u8, 99), m.timing.sound_timer);
+    try std.testing.expectEqual(@as(u8, 99), m.cpu.v[0x3]);
     try std.testing.expectEqual(@as(u8, 0xBB), m.timing.delay_timer);
+    try std.testing.expectEqual(@as(u16, 0x202), m.cpu.pc);
+}
+
+test "FX18 then tickTimers then isBeeping observes the 60 Hz decrement through the ROM-visible interface" {
+    var m = Machine.init(.{});
+    defer m.deinit();
+    m.cpu.v[0x3] = 2;
+    try m.loadRom(&assemble(.{0xF318}));
+
+    _ = m.step();
+    try std.testing.expect(m.isBeeping());
+    m.tickTimers();
+    try std.testing.expect(m.isBeeping());
+    m.tickTimers();
+    try std.testing.expect(!m.isBeeping());
+}
+
+test "FX18 with V[X] = 0 leaves isBeeping false (vanilla VIP — store, not OR)" {
+    var m = Machine.init(.{});
+    defer m.deinit();
+    m.cpu.v[0x3] = 0;
+    m.timing.sound_timer = 7;
+    try m.loadRom(&assemble(.{0xF318}));
+
+    try std.testing.expectEqual(StepResult.ran, m.step());
+
+    try std.testing.expectEqual(@as(u8, 0), m.timing.sound_timer);
+    try std.testing.expect(!m.isBeeping());
 }
 
 test "FX29 ignores the high nibble of VX (digit selected from low 4 bits only)" {


### PR DESCRIPTION
## Summary

- Adds the `0x18` FX-family dispatch arm in `Machine.step` — `Timing.sound_timer = V[X]` — replacing the M2.8 silent fall-through.
- Adds the matching `disasm` entry (`LD ST, VX`) in lockstep per the M4.1 disasm-in-lockstep lesson, with the prior unknown-sentinel test replaced by a positive assertion.
- Replaces the existing `FX18 falls through silently` stub with three real unit tests, modeled on the FX07 / FX15 / FX1E pattern: direct set, cross-tick decrement observed through `Machine.isBeeping()`, and `V[X] = 0` clear (pinned by pre-loading a non-zero `sound_timer` so the test fails if FX18 stops running or implements an OR/max instead of a store).

Closes #101 (M5.1). Parent PRD: #100.

## Test plan

- [x] `nix develop -c zig build test` — green (4 new asserts, 0 regressions).
- [x] Existing goldens (`ibm_logo`, `corax+`, `5-quirks`, `6-keypad`) bit-identical.
- [x] CI grep tests for `chippy_core` invariants — green.
- [ ] CI green on `ubuntu-latest` ∩ `macos-latest` (awaiting first push).

## Out of scope (per #101)

- `AudioSink` contract — M5.2.
- `Beeper` glossary entry in `CONTEXT.md` — M5.2.
- `golden_harness.RunOptions.audio_sink` extension — M5.2.
- TUI "BEEP" indicator — M5.2.
- ADR 0015 — M5.2.
- Timendus beep-test ROM golden — M5.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)